### PR TITLE
Correct traditional 面條 -> 麵條

### DIFF
--- a/cordova-build-override/www/assets/lists/nhsk2.list
+++ b/cordova-build-override/www/assets/lists/nhsk2.list
@@ -143,7 +143,7 @@
 教室	教室	jiao4shi4	jiàoshì	classroom
 跑步	跑步	pao3 bu4	pǎo bù	to run; to jog
 阴	陰	yin1	yīn	cloudy (weather); yin (the negative principle of Yin and Yang); secret; the moon; negative; shade
-面条	面條	mian4tiao2	miàntiáo	noodles
+面条	麵條	mian4tiao2	miàntiáo	noodles
 铅笔	鉛筆	qian1bi3	qiānbǐ	pencil
 火车站	火車站	huo3che1zhan4	huǒchēzhàn	train station
 西瓜	西瓜	xi1gua1	xīguā	watermelon


### PR DESCRIPTION
For context, https://zh.wikipedia.org/zh-tw/%E9%9D%A2%E6%9D%A1 displays it as the full traditional form, although I'm sure it's occasionally written in a mixed state.