### PR TITLE
Add TOCFL (華語文能力測驗) lists for learners of Traditional Chinese

### DIFF
--- a/cordova-build-override/www/assets/lists/tocfl1.list
+++ b/cordova-build-override/www/assets/lists/tocfl1.list
@@ -1,0 +1,57 @@
+你们	你們	ni3 men5	you (plural)
+他们	他們	ta1 men5	they
+谁	誰	shei2	who
+中国	中國	zhong1 guo2	China
+美国	美國	mei3 guo2	United States
+台湾	台灣	tai2 wan1	variant of 臺灣|台湾[Tai2 wan1]
+电话	電話	dian4 hua4	telephone
+现在	現在	xian4 zai4	now
+两	兩	liang3	two
+时候	時候	shi2 hou4	time
+妈妈	媽媽	ma1 ma5	mama
+点	點	dian3	point
+个	個	ge5	individual
+岁	歲	sui4	classifier for years (of age)
+来	來	lai2	to come
+觉得	覺得	jue2 de5	to think
+喜欢	喜歡	xi3 huan1	to like
+打电话	打電話	da3 dian4 hua4	to make a telephone call
+高兴	高興	gao1 xing4	happy
+电脑	電腦	dian4 nao3	computer
+老师	老師	lao3 shi1	teacher
+买	買	mai3	to buy
+学生	學生	xue2 sheng1	student
+大学	大學	da4 xue2	the Great Learning, one of the Four Books 四書|四书[Si4 shu1] in Confucianism
+学校	學校	xue2 xiao4	school
+笔	筆	bi3	pen
+问	問	wen4	to ask
+说	說	shuo1	to persuade
+写	寫	xie3	to write
+听	聽	ting1	to listen
+练习	練習	lian4 xi2	to practice
+上课	上課	shang4 ke4	to go to class
+电视	電視	dian4 shi4	television
+书	書	shu1	book
+电影	電影	dian4 ying3	movie
+以后	以後	yi3 hou4	after
+什么	什麼	shen2 me5	what?
+东西	東西	dong1 xi5	east and west
+吗	嗎	ma5	(question particle for 'yes-no' questions)
+再见	再見	zai4 jian4	goodbye
+怎么样	怎麼樣	zen3 me5 yang4	how?
+谢谢	謝謝	xie4 xie5	to thank
+对不起	對不起	dui4 bu5 qi3	unworthy
+请问	請問	qing3 wen4	Excuse me, may I ask...?
+这	這	zhe4	this
+公共汽车	公共汽車	gong1 gong4 qi4 che1	bus
+开车	開車	kai1 che1	to drive a car
+钱	錢	qian2	coin
+给	給	gei3	to
+贵	貴	gui4	expensive
+难	難	nan2	difficult (to...)
+几	幾	ji3	almost
+块	塊	kuai4	lump (of earth)
+饭	飯	fan4	food
+没	沒	mei2	(negative prefix for verbs)
+还是	還是	hai2 shi4	or
+过	過	guo4	to cross

--- a/cordova-build-override/www/assets/lists/tocfl2.list
+++ b/cordova-build-override/www/assets/lists/tocfl2.list
@@ -1,0 +1,68 @@
+女儿	女兒	nü3 er2	daughter
+儿子	兒子	er2 zi5	son
+手机	手機	shou3 ji1	cell phone
+号码	號碼	hao4 ma3	number
+周末	週末	zhou1 mo4	weekend
+从	從	cong2	from
+爱	愛	ai4	to love
+快乐	快樂	kuai4 le4	happy
+医生	醫生	yi1 sheng1	doctor
+医院	醫院	yi1 yuan4	hospital
+卖	賣	mai4	to sell
+准备	準備	zhun3 bei4	preparation
+一点	一點	yi1 dian3	a bit
+张	張	zhang1	to open up
+中学	中學	zhong1 xue2	middle school
+年级	年級	nian2 ji2	grade
+纸	紙	zhi3	paper
+问题	問題	wen4 ti2	question
+图书馆	圖書館	tu2 shu1 guan3	library
+数学	數學	shu4 xue2	mathematics
+历史	歷史	li4 shi3	history
+餐厅	餐廳	can1 ting1	dining hall
+学习	學習	xue2 xi2	to learn
+参加	參加	can1 jia1	to participate
+画	畫	hua4	to draw
+读	讀	du2	comma
+会	會	hui4	can
+为什么	為什麼	wei4 shen2 me5	why?
+下课	下課	xia4 ke4	to finish class
+说话	說話	shuo1 hua4	to speak
+考试	考試	kao3 shi4	to take an exam
+天气	天氣	tian1 qi4	weather
+门	門	men2	gate
+客厅	客廳	ke4 ting1	drawing room (room for arriving guests)
+风	風	feng1	wind
+鱼	魚	yu2	fish
+树	樹	shu4	tree
+热	熱	re4	to warm up
+睡觉	睡覺	shui4 jiao4	to go to bed
+音乐	音樂	yin1 yue4	music
+运动	運動	yun4 dong4	to move
+开始	開始	kai1 shi3	to begin
+介绍	介紹	jie4 shao4	to introduce (sb to sb)
+换	換	huan4	to exchange
+认识	認識	ren4 shi5	to know
+没关系	沒關係	mei2 guan1 xi5	it doesn't matter
+怎么	怎麼	zen3 me5	how?
+哪里	哪裡	na3 li3	where?
+这里	這裡, 這裏	zhe4 li3	here
+那里	那裡	na4 li3	there
+右边	右邊	you4 bian1	right side
+左边	左邊	zuo3 bian1	left
+旁边	旁邊	pang2 bian1	lateral
+中间	中間	zhong1 jian1	between
+地铁	地鐵	di4 tie3	subway
+离	離	li2	to leave
+带	帶	dai4	band
+进来	進來	jin4 lai2	to come in
+远	遠	yuan3	far
+身体	身體	shen1 ti3	the body
+药	藥	yao4	medicine
+双	雙	shuang1	two
+裤子	褲子	ku4 zi5	trousers
+市场	市場	shi4 chang3	marketplace
+长	長	chang2	length
+一样	一樣	yi1 yang4	same
+苹果	蘋果	ping2 guo3	apple
+因为	因為	yin1 wei4	because

--- a/cordova-build-override/www/assets/lists/tocfl3.list
+++ b/cordova-build-override/www/assets/lists/tocfl3.list
@@ -1,0 +1,94 @@
+公园	公園	gong1 yuan2	park (for public recreation)
+国家	國家	guo2 jia1	country
+电子邮件	電子郵件	dian4 zi3 you2 jian4	email
+结婚	結婚	jie2 hun1	to marry
+小时	小時	xiao3 shi2	hour
+点钟	點鐘	dian3 zhong1	(indicating time of day) o'clock
+分钟	分鐘	fen1 zhong1	minute
+年轻	年輕	nian2 qing1	young
+紧张	緊張	jin3 zhang1	nervous
+可爱	可愛	ke3 ai4	adorable
+万	萬	wan4	ten thousand
+办公室	辦公室	ban4 gong1 shi4	office
+工厂	工廠	gong1 chang3	factory
+护士	護士	hu4 shi4	nurse
+司机	司機	si1 ji1	chauffeur
+老板	老闆	lao3 ban3	Robam (brand)
+小学	小學	xiao3 xue2	elementary school
+上学	上學	shang4 xue2	to go to school
+作业	作業	zuo4 ye4	school assignment
+功课	功課	gong1 ke4	homework
+请假	請假	qing3 jia4	to request leave of absence
+洗手间	洗手間	xi3 shou3 jian1	toilet
+语言	語言	yu3 yan2	language
+科学	科學	ke1 xue2	science
+华语	華語	hua2 yu3	Chinese language
+课本	課本	ke4 ben3	textbook
+读书	讀書	du2 shu1	to read a book
+决定	決定	jue2 ding4	to decide (to do something)
+图片	圖片	tu2 pian4	image
+记得	記得	ji4 de5	to remember
+房间	房間	fang2 jian1	room
+厨房	廚房	chu2 fang2	kitchen
+楼	樓	lou2	house with more than 1 story
+楼上	樓上	lou2 shang4	upstairs
+楼下	樓下	lou2 xia4	downstairs
+电梯	電梯	dian4 ti1	elevator
+沙发	沙發	sha1 fa1	sofa (loanword)
+冷气	冷氣	leng3 qi4	air conditioning (Tw)
+安静	安靜	an1 jing4	quiet
+不错	不錯	bu4 cuo4	correct
+海边	海邊	hai3 bian1	coast
+马	馬	ma3	horse
+鸟	鳥	niao3	penis
+猫	貓	mao1	cat
+鸡	雞	ji1	fowl
+太阳	太陽	tai4 yang2	sun
+篮球	籃球	lan2 qiu2	basketball
+网球	網球	wang3 qiu2	tennis
+比赛	比賽	bi3 sai4	competition (sports etc)
+骑	騎	qi2	(Taiwan) saddle horse
+脚踏车	腳踏車	jiao3 ta4 che1	bicycle
+电影院	電影院	dian4 ying3 yuan4	cinema
+上网	上網	shang4 wang3	to go online
+输	輸	shu1	to lose
+赢	贏	ying2	to beat
+有时候	有時候	you3 shi2 hou5	sometimes
+报纸	報紙	bao4 zhi3	newspaper
+不客气	不客氣	bu4 ke4 qi4	you're welcome
+礼物	禮物	li3 wu4	gift
+欢迎	歡迎	huan1 ying2	to welcome
+晚会	晚會	wan3 hui4	evening party
+邮局	郵局	you2 ju2	post office
+银行	銀行	yin2 hang2	bank
+坏	壞	huai4	bad
+帮忙	幫忙	bang1 mang2	to help
+计程车	計程車	ji4 cheng2 che1	taxi
+车站	車站	che1 zhan4	rail station
+火车	火車	huo3 che1	train
+飞机	飛機	fei1 ji1	airplane
+飞机场	飛機場	fei1 ji1 chang3	airport
+马路	馬路	ma3 lu4	street
+对面	對面	dui4 mian4	(sitting) opposite
+里面	裡面	li3 mian4	inside
+饭店	飯店	fan4 dian4	restaurant
+旅馆	旅館	lü3 guan3	hotel
+参观	參觀	can1 guan1	to look around
+地图	地圖	di4 tu2	map
+照相机	照相機	zhao4 xiang4 ji1	camera
+风景	風景	feng1 jing3	scenery
+头	頭	tou2	head
+头发	頭髮	tou2 fa3	hair (on the head)
+受伤	受傷	shou4 shang1	to sustain injuries
+饿	餓	e4	to be hungry
+眼镜	眼鏡	yan3 jing4	spectacles
+颜色	顏色	yan2 se4	color
+黄色	黃色	huang2 se4	yellow (color)
+袜子	襪子	wa4 zi5	socks
+饺子	餃子	jiao3 zi5	dumpling
+面	麵	mian4	flour
+汤	湯	tang1	rushing current
+面包	麵包	mian4 bao1	bread
+饮料	飲料	yin3 liao4	drink
+菜单	菜單	cai4 dan1	menu
+盘子	盤子	pan2 zi5	tray

--- a/cordova-build-override/www/assets/lists/tocfl4.list
+++ b/cordova-build-override/www/assets/lists/tocfl4.list
@@ -1,0 +1,227 @@
+传真	傳真	chuan2 zhen1	fax
+时间	時間	shi2 jian1	time
+钟头	鐘頭	zhong1 tou2	hour
+礼拜	禮拜	li3 bai4	week
+礼拜天	禮拜天	li3 bai4 tian1	Sunday
+后天	後天	hou4 tian1	the day after tomorrow
+从前	從前	cong2 qian2	previously
+一会儿	一會兒	yi1 hui3 er2	a moment
+刚刚	剛剛	gang1 gang1	just recently
+刚才	剛才	gang1 cai2	just now
+当然	當然	dang1 ran2	only natural
+别人	別人	bie2 ren2	other people
+年纪	年紀	nian2 ji4	age
+习惯	習慣	xi2 guan4	habit
+父亲	父親	fu4 qin1	father
+母亲	母親	mu3 qin1	mother
+爷爷	爺爺	ye2 ye5	(coll.) father's father
+关系	關係	guan1 xi4	relation
+开心	開心	kai1 xin1	to feel happy
+着急	著急	zhao1 ji2	to worry
+担心	擔心	dan1 xin1	anxious
+生气	生氣	sheng1 qi4	to get angry
+难过	難過	nan2 guo4	to feel sad
+伤心	傷心	shang1 xin1	to grieve
+美丽	美麗	mei3 li4	beautiful
+聪明	聰明	cong1 ming2	intelligent
+认真	認真	ren4 zhen1	conscientious
+礼貌	禮貌	li3 mao4	courtesy
+应该	應該	ying1 gai1	ought to
+经验	經驗	jing1 yan4	experience
+关心	關心	guan1 xin1	to be concerned about
+愿意	願意	yuan4 yi4	to wish
+可怜	可憐	ke3 lian2	pitiful
+职业	職業	zhi2 ye4	occupation
+教师	教師	jiao4 shi1	teacher
+经理	經理	jing1 li3	manager
+记者	記者	ji4 zhe3	reporter
+服务员	服務員	fu2 wu4 yuan2	waiter
+顾客	顧客	gu4 ke4	client
+教书	教書	jiao1 shu1	to teach (in a school)
+开会	開會	kai1 hui4	to hold a meeting
+危险	危險	wei2 xian3	danger
+报告	報告	bao4 gao4	to inform
+机会	機會	ji1 hui4	opportunity
+计画	計畫	ji4 hua4	variant of 計劃|计划[ji4 hua4]
+学院	學院	xue2 yuan4	college
+小学生	小學生	xiao3 xue2 sheng1	primary school student
+大学生	大學生	da4 xue2 sheng1	university student
+同学	同學	tong2 xue2	to study at the same school
+校长	校長	xiao4 zhang3	(college, university) president
+毕业	畢業	bi4 ye4	graduation
+开学	開學	kai1 xue2	foundation of a University or College
+成绩	成績	cheng2 ji1	achievement
+学期	學期	xue2 qi2	term
+学费	學費	xue2 fei4	tuition fee
+服务	服務	fu2 wu4	to serve
+操场	操場	cao1 chang3	playground
+校园	校園	xiao4 yuan2	campus
+语法	語法	yu3 fa3	grammar
+汉语	漢語	han4 yu3	Chinese language
+书法	書法	shu1 fa3	calligraphy
+书桌	書桌	shu1 zhuo1	desk
+汉字	漢字	han4 zi4	Chinese character
+铅笔	鉛筆	qian1 bi3	(lead) pencil
+毛笔	毛筆	mao2 bi3	writing brush
+讲	講	jiang3	to speak
+讲话	講話	jiang3 hua4	a speech
+告诉	告訴	gao4 su4	to press charges
+讨论	討論	tao3 lun4	to discuss
+认为	認為	ren4 wei2	to believe
+解释	解釋	jie3 shi4	explanation
+无聊	無聊	wu2 liao2	bored
+办法	辦法	ban4 fa3	means
+进步	進步	jin4 bu4	progress
+大楼	大樓	da4 lou2	building (a relatively large, multi-storey one)
+卧室	臥室	wo4 shi4	bedroom
+花园	花園	hua1 yuan2	garden
+门口	門口	men2 kou3	doorway
+楼梯	樓梯	lou2 ti1	stair
+墙	牆	qiang2	wall
+洗衣机	洗衣機	xi3 yi1 ji1	washer
+灯	燈	deng1	lamp
+打开	打開	da3 kai1	to open
+邻居	鄰居	lin2 ju1	neighbor
+热闹	熱鬧	ren4 ao5	bustling with noise and excitement
+满意	滿意	man3 yi4	satisfied
+干净	乾淨	gan1 jing4	clean
+开水	開水	kai1 shui3	boiled water
+乡下	鄉下	xiang1 xia4	countryside
+只	隻	zhi1	classifier for birds and certain animals, one of a pair, some utensils, vessels etc
+动物	動物	dong4 wu4	animal
+猪	豬	zhu1	hog
+云	雲	yun2	cloud
+环境	環境	huan2 jing4	environment
+凉快	涼快	liang2 kuai4	nice and cold
+温暖	溫暖	wen1 nuan3	warm
+温度	溫度	wen1 du4	temperature
+空气	空氣	kong1 qi4	air
+发生	發生	fa1 sheng1	to happen
+发现	發現	fa1 xian4	to find
+照顾	照顧	zhao4 gu4	to take care of
+打扫	打掃	da3 sao3	to clean
+起来	起來	qi3 lai2	to stand up
+挂	掛	gua4	to hang or suspend (from a hook etc)
+过年	過年	guo4 nian2	to celebrate the Chinese New Year
+结束	結束	jie2 shu4	termination
+博物馆	博物館	bo2 wu4 guan3	museum
+节目	節目	jie2 mu4	program
+新闻	新聞	xin1 wen2	news
+体育	體育	ti3 yu4	sports
+网站	網站	wang3 zhan4	website
+经常	經常	jing1 chang2	frequently
+总是	總是	zong3 shi4	always
+已经	已經	yi3 jing1	already
+杂志	雜誌	za2 zhi4	magazine
+小说	小說	xiao3 shuo1	novel
+美术	美術	mei3 shu4	art
+艺术	藝術	yi4 shu4	art
+兴趣	興趣	xing4 qu4	interest (desire to know about sth)
+谈	談	tan2	to speak
+迟到	遲到	chi2 dao4	to arrive late
+后来	後來	hou4 lai2	afterwards
+变	變	bian4	to change
+乐器	樂器	yue4 qi4	musical instrument
+钢琴	鋼琴	gang1 qin2	piano
+活动	活動	huo2 dong4	to exercise
+怎么了	怎麼了	zen3 me5 le5	What's up?
+怎么办	怎麼辦	zen3 me5 ban4	what's to be done
+客气	客氣	ke4 qi5	polite
+舞会	舞會	wu3 hui4	dance
+请客	請客	qing3 ke4	to give a dinner party
+庆祝	慶祝	qing4 zhu4	to celebrate
+听说	聽說	ting1 shuo1	to hear (sth said)
+感谢	感謝	gan3 xie4	(express) thanks
+见面	見面	jian4 mian4	to meet
+约	約	yue1	to weigh in a balance or on a scale
+检查	檢查	jian3 cha2	inspection
+麻烦	麻煩	ma2 fan5	inconvenient
+钱包	錢包	qian2 bao1	purse
+丢	丟	diu1	to lose
+汽车	汽車	qi4 che1	car
+辆	輛	liang4	classifier for vehicles
+停车场	停車場	ting2 che1 chang3	parking lot
+起飞	起飛	qi3 fei1	(of an aircraft) to take off
+出来	出來	chu1 lai2	to come out
+进去	進去	jin4 qu4	to go in
+红绿灯	紅綠燈	hong2 lü4 deng1	traffic light
+桥	橋	qiao2	bridge
+这边	這邊	zhe4 bian1	this side
+这些	這些	zhe4 xie1	these
+那边	那邊	na4 bian1	over there
+旅游	旅遊	lü3 you2	trip
+动物园	動物園	dong4 wu4 yuan2	zoo
+出发	出發	chu1 fa1	to set off
+离开	離開	li2 kai1	to depart
+南边	南邊	nan2 bian1	south
+西边	西邊	xi1 bian1	west
+北边	北邊	bei3 bian1	north
+东部	東部	dong1 bu4	the east
+东边	東邊	dong1 bian1	east
+经过	經過	jing1 guo4	to pass
+转	轉	zhuan3	to turn
+过去	過去	guo4 qu4	(in the) past
+最后	最後	zui4 hou4	final
+外国	外國	wai4 guo2	foreign (country)
+护照	護照	hu4 zhao4	passport
+钥匙	鑰匙	yao4 shi5	key
+出现	出現	chu1 xian4	to appear
+脸	臉	lian3	face
+感觉	感覺	gan3 jue2	to feel
+救护车	救護車	jiu4 hu4 che1	ambulance
+发烧	發燒	fa1 shao1	to have a high temperature (from illness)
+保险	保險	bao3 xian3	insurance
+挂号	掛號	gua4 hao4	to register (at a hospital etc)
+药房	藥房	yao4 fang2	pharmacy
+恢复	恢復	hui1 fu4	to reinstate
+影响	影響	ying3 xiang3	influence
+饱	飽	bao3	to eat till full
+吃饱	吃飽	chi1 bao3	to eat one's fill
+简单	簡單	jian3 dan1	simple
+书店	書店	shu1 dian4	bookstore
+超级市场	超級市場	chao1 ji2 shi4 chang3	supermarket
+蓝色	藍色	lan2 se4	blue (color)
+绿色	綠色	lü4 se4	green
+红色	紅色	hong2 se4	red (color)
+衬衫	襯衫	chen4 shan1	shirt
+牛仔裤	牛仔褲	niu2 zai3 ku4	jeans
+内衣	內衣	nei4 yi1	undergarment
+旧	舊	jiu4	old
+价格	價格	jia4 ge2	price
+价钱	價錢	jia4 qian2	price
+排队	排隊	pai2 dui4	to line up
+比较	比較	bi3 jiao4	to compare
+样子	樣子	yang4 zi5	appearance
+特别	特別	te4 bie2	especially
+圆	圓	yuan2	circle
+看见	看見	kan4 ji5	to see
+声音	聲音	sheng1 yin1	voice
+大声	大聲	da4 sheng1	loud voice
+红茶	紅茶	hong2 cha2	black tea
+点菜	點菜	dian3 cai4	to order dishes (in a restaurant)
+咸	鹹	xian2	salted
+点心	點心	dian3 xin1	light refreshments
+饼干	餅乾	bing3 gan1	biscuit
+汉堡	漢堡	han4 bao3	hamburger (loanword)
+盐	鹽	yan2	salt
+条	條	tiao2	strip
+种	種	zhong3	seed
+够	夠	gou4	enough (sufficient)
+许多	許多	xu3 duo1	many
+新鲜	新鮮	xin1 xian5	fresh (experience, food etc)
+尝	嚐, 嘗	chang2 chang2 shi4	to taste
+装	裝	zhuang1	adornment
+汤匙	湯匙	tang1 chi2	soup spoon
+没有	沒有	mei2 you3	haven't
+马上	馬上	ma3 shang4	at once
+让	讓	rang4	to yield
+然后	然後	ran2 hou4	after
+虽然	雖然	sui1 ran2	although
+原来	原來	yuan2 lai2	original
+也许	也許	ye3 xu3	perhaps
+为了	為了	wei4 le5	in order to
+必须	必須	bi4 xu1	to have to
+永远	永遠	yong3 yuan3	forever
+那么	那麼	na4 me5	like that
+这么	這麼	zhe4 me5	so much
+本来	本來	ben3 lai2	original

--- a/cordova-build-override/www/assets/lists/tocfl5.list
+++ b/cordova-build-override/www/assets/lists/tocfl5.list
@@ -1,0 +1,603 @@
+爱情	愛情	ai4 qing2	romance
+爱惜	愛惜	ai4 xi2	to cherish
+爱心	愛心	ai4 xin1	compassion
+摆	擺	bai3	to arrange
+百货公司	百貨公司	bai3 huo4 gong1 si1	department store
+班机	班機	ban1 ji1	airliner
+办理	辦理	ban4 li3	to handle
+帮助	幫助	bang1 zhu4	assistance
+榜样	榜樣	bang3 yang4	example
+宝贝	寶貝	bao3 bei4	treasured object
+宝贵	寶貴	bao3 gui4	valuable
+保护	保護	bao3 hu4	to protect
+保养	保養	bao3 yang3	to take good care of (or conserve) one's health
+保证	保證	bao3 zheng4	guarantee
+报名	報名	bao4 ming2	to sign up
+被动	被動	bei4 dong4	passive
+背后	背後	bei4 hou4	behind
+辈子	輩子	bei4 zi5	all one's life
+毕竟	畢竟	bi4 jing4	after all
+变成	變成	bian4 cheng2	to change into
+变更	變更	bian4 geng1	to change
+变化	變化	bian4 hua4	change
+便条	便條	bian4 tiao2	(informal) note
+标准	標準	biao1 zhun3	(an official) standard
+表达	表達	biao3 da2	to express
+表现	表現	biao3 xian4	to show
+别的	別的	bie2 de5	else
+冰块	冰塊	bing1 kuai4	ice cube
+不断	不斷	bu4 duan4	unceasing
+不过	不過	bu4 guo4	only
+不见	不見	bu4 jian4	not to see
+不论	不論	bu4 lun4	whatever
+不满	不滿	bu4 man3	resentful
+部门	部門	bu4 men2	department
+采用	採用	cai3 yong4	to adopt
+参考	參考	can1 kao3	consultation
+层	層	ceng2	layer
+曾经	曾經	ceng2 jing1	once
+差别	差別	cha1 bie2	difference
+差异	差異	cha1 yi4	difference
+差点儿	差點兒	cha4 dian3 r5	erhua variant of 差點|差点[cha4 dian3]
+产品	產品	chan3 pin3	goods
+产生	產生	chan3 sheng1	to arise
+超过	超過	chao1 guo4	to surpass
+超级	超級	chao1 ji2	super-
+车祸	車禍	che1 huo4	traffic accident
+成长	成長	cheng2 zhang3	to mature
+承认	承認	cheng2 ren4	to admit
+诚实	誠實	cheng2 shi2	honest
+吃喝玩乐	吃喝玩樂	chi1 he1 wan2 le4	to eat, drink and be merry (idiom)
+充实	充實	chong1 shi2	rich
+虫	蟲	chong2	lower form of animal life, including insects, insect larvae, worms and similar creatures
+丑	醜	chou3	shameful
+出门	出門	chu1 men2	to go out
+厨师	廚師	chu2 shi1	cook
+处理	處理	chu3 li3	to handle
+传统	傳統	chuan2 tong3	tradition
+创造	創造	chuang4 zao4	to create
+春节	春節	chun1 jie2	Spring Festival (Chinese New Year)
+词	詞	ci2	word
+从不	從不	cong2 bu4	never
+从来	從來	cong2 lai2	always
+从小	從小	cong2 xiao3	from childhood
+错误	錯誤	cuo4 wu4	error
+答应	答應	da1 ying4	to answer
+达成	達成	da2 cheng2	to reach (an agreement)
+打听	打聽	da3 ting1	to ask about
+大多数	大多數	da4 duo1 shu4	(great) majority
+大会	大會	da4 hui4	general assembly
+大陆	大陸	da4 lu4	mainland China (reference to the PRC)
+大门	大門	da4 men2	entrance
+大约	大約	da4 yue1	approximately
+带来	帶來	dai4 lai2	to bring
+带领	帶領	dai4 ling3	to guide
+单纯	單純	dan1 chun2	simple
+单身	單身	dan1 shen1	unmarried
+担任	擔任	dan1 ren4	to hold a governmental office or post
+当场	當場	dang1 chang3	at the scene
+当地	當地	dang1 di4	local
+当面	當面	dang1 mian4	to sb's face
+当年	當年	dang1 nian2	in those days
+当天	當天	dang4 tian1	on that day
+当中	當中	dang1 zhong1	among
+当作	當作	dang4 zuo4	to treat as
+当做	當做	dang4 zuo4	to treat as
+岛	島	dao3	island
+导演	導演	dao3 yan3	to direct
+到处	到處	dao4 chu4	everywhere
+的话	的話	de5 hua4	if (coming after a conditional clause)
+灯光	燈光	deng1 guang1	(stage) lighting
+敌人	敵人	di2 ren2	enemy
+抵达	抵達	di3 da2	to arrive
+地带	地帶	di4 dai4	zone
+地点	地點	di4 dian3	place
+地区	地區	di4 qu1	local
+地摊	地攤	di4 tan1	street stall with goods laid out on the ground
+电车	電車	dian4 che1	trolleybus
+电池	電池	dian4 chi2	battery
+电灯	電燈	dian4 deng1	electric light
+店员	店員	dian4 yuan2	shop assistant
+调查	調查	diao4 cha2	investigation
+订	訂	ding4	to agree
+东北	東北	dong1 bei3	Northeast China
+东方	東方	dong1 fang1	the East
+东南	東南	dong1 nan2	southeast
+豆浆	豆漿	dou4 jiang1	soy milk
+独特	獨特	du2 te4	unique
+读者	讀者	du2 zhe3	reader
+对方	對方	dui4 fang1	counterpart
+对话	對話	dui4 hua4	dialogue
+对了	對了	dui4 le5	Correct!
+对象	對象	dui4 xiang4	target
+多么	多麼	duo1 me5	how (wonderful etc)
+顿	頓	dun4	to stop
+儿童	兒童	er2 tong2	child
+发表	發表	fa1 biao3	to issue
+发财	發財	fa1 cai2	to get rich
+发出	發出	fa1 chu1	to issue (an order, decree etc)
+发达	發達	fa1 da2	developed (country etc)
+发挥	發揮	fa1 hui1	to display
+发觉	發覺	fa1 jue2	to become aware
+发明	發明	fa1 ming2	to invent
+发脾气	發脾氣	fa1 pi2 qi5	to get angry
+发票	發票	fa1 piao4	invoice
+翻译	翻譯	fan1 yi4	to translate
+烦恼	煩惱	fan2 nao3	to be worried
+反应	反應	fan3 ying4	to react
+范围	範圍	fan4 wei2	range
+房东	房東	fang2 dong1	landlord
+访问	訪問	fang3 wen4	to visit
+费用	費用	fei4 yong4	cost
+分开	分開	fen1 kai1	to separate
+丰富	豐富	feng1 fu4	to enrich
+风格	風格	feng1 ge2	style
+风俗	風俗	feng1 su2	social custom
+否则	否則	fou3 ze2	if not
+夫妇	夫婦	fu1 fu4	a (married) couple
+服装	服裝	fu2 zhuang1	dress
+腐败	腐敗	fu3 bai4	corruption
+负担	負擔	fu4 dan1	burden
+负责	負責	fu4 ze2	to be in charge of
+复习	複習	fu4 xi2	variant of 復習|复习[fu4 xi2]
+改变	改變	gai3 bian4	to change
+改进	改進	gai3 jin4	to improve
+盖	蓋	gai4	lid
+赶	趕	gan3	to overtake
+赶快	趕快	gan3 kuai4	at once
+赶上	趕上	gan3 shang4	to keep up with
+感动	感動	gan3 dong4	to move (sb)
+感兴趣	感興趣	gan3 xing4 qu4	to be interested
+个人	個人	ge4 ren2	individual
+个子	個子	ge4 zi5	height
+各式各样	各式各樣	ge4 shi4 ge4 yang4	(of) all kinds and sorts
+根据	根據	gen1 ju4	according to
+工业	工業	gong1 ye4	industry
+贡献	貢獻	gong4 xian4	to contribute
+沟通	溝通	gou1 tong1	to join
+购买	購買	gou4 mai3	to purchase
+观察	觀察	guan1 cha2	to observe
+观点	觀點	guan1 dian3	point of view
+观念	觀念	guan1 nian4	notion
+观众	觀眾	guan1 zhong4	spectators
+广播	廣播	guang3 bo4	broadcast
+广场	廣場	guang3 chang3	public square
+广告	廣告	guang3 gao4	to advertise
+规矩	規矩	gui1 ju3	lit. compass and set square
+规模	規模	gui1 mo2	scale
+贵姓	貴姓	gui4 xing4	what is your surname?
+柜子	櫃子	gui4 zi5	cupboard
+国内	國內	guo2 nei4	domestic
+国外	國外	guo2 wai4	abroad
+国王	國王	guo2 wang2	king
+国语	國語	guo2 yu3	Chinese language (Mandarin), emphasizing its national nature
+过日子	過日子	guo4 ri4 zi5	to live one's life
+还好	還好	hai2 hao3	not bad
+海报	海報	hai3 bao4	poster
+海滩	海灘	hai3 tan1	beach
+好处	好處	hao3 chu4	benefit
+好几	好幾	hao3 ji3	several
+红包	紅包	hong2 bao1	money wrapped in red as a gift
+红豆	紅豆	hong2 dou4	azuki bean
+糊涂	糊塗	hu2 tu2	muddled
+画家	畫家	hua4 jia1	painter
+话说回来	話說回來	hua4 shuo1 hui2 lai2	returning to our main topic,...
+话题	話題	hua4 ti2	subject (of a talk or conversation)
+化妆品	化妝品	hua4 zhuang1 pin3	cosmetic
+坏处	壞處	huai4 chu4	harm
+环保	環保	huan2 bao3	environmental protection
+会场	會場	hui4 chang3	meeting place
+会话	會話	hui4 hua4	conversation
+会议	會議	hui4 yi4	meeting
+婚礼	婚禮	hun1 li3	wedding ceremony
+混乱	混亂	hun4 luan4	confusion
+或许	或許	huo4 xu3	perhaps
+基础	基礎	ji1 chu3	base
+激动	激動	ji1 dong4	to move emotionally
+积极	積極	ji1 ji2	active
+机器	機器	ji1 qi4	machine
+极了	極了	ji2 le5	extremely
+挤	擠	ji3	to crowd in
+记录	記錄	ji4 lu4	to record
+记忆	記憶	ji4 yi4	to remember
+季节	季節	ji4 jie2	time
+纪念	紀念	jin4 an4	to commemorate
+继续	繼續	ji4 xu4	to continue
+加强	加強	jia1 qiang2	to reinforce
+家乡	家鄉	jia1 xiang1	hometown
+家长	家長	jia1 zhang3	head of a household
+假装	假裝	jia3 zhuang1	to feign
+价值	價值	jia4 zhi2	value
+坚持	堅持	jian1 chi2	to persevere with
+坚强	堅強	jian1 qiang2	staunch
+减	減	jian3	to lower
+减轻	減輕	jian3 qing1	to lighten
+减少	減少	jian3 shao3	to lessen
+简直	簡直	jian3 zhi2	simply
+建设	建設	jian4 she4	to build
+建议	建議	jian4 yi4	to propose
+将来	將來	jiang1 lai2	in the future
+讲价	講價	jiang3 jia4	to bargain (over price)
+讲究	講究	jiang3 jiu5	to pay particular attention to
+奖学金	獎學金	jiang3 xue2 jin1	scholarship
+酱油	醬油	jiang4 you2	soy sauce
+骄傲	驕傲	jiao1 ao4	pride
+郊区	郊區	jiao1 qu1	suburban district
+教导	教導	jiao4 dao3	to instruct
+教练	教練	jiao4 lian4	instructor
+教训	教訓	jiao4 xun5	lesson
+接触	接觸	jie1 chu4	to touch
+接着	接著	jie1 zhe5	to catch and hold on
+结果	結果	jie2 guo3	to bear fruit
+结局	結局	jie2 ju2	conclusion
+节日	節日	jie2 ri4	holiday
+解决	解決	jie3 jue2	to settle (a dispute)
+仅	僅	jin3	barely
+尽管	儘管	jin3 guan3	despite
+进行	進行	jin4 xing2	to advance
+进一步	進一步	jin4 yi2 bu4	one step further
+经费	經費	jing1 fei4	funds
+惊讶	驚訝	jing1 ya4	amazed
+舅妈	舅媽	jiu4 ma1	(coll.) aunt
+举	舉	ju3	to lift
+举办	舉辦	ju3 ban4	to conduct
+举手	舉手	ju3 shou3	to raise a hand
+举行	舉行	ju3 xing2	to hold (a meeting, ceremony etc)
+剧本	劇本	ju4 ben3	script for play, opera, movie etc
+剧情	劇情	ju4 qing2	story line
+拒绝	拒絕	ju4 jue2	to refuse
+距离	距離	ju4 li2	distance
+绝对	絕對	jue2 dui4	absolute
+军队	軍隊	jun1 dui4	army
+军人	軍人	jun1 ren2	serviceman
+卡车	卡車	ka3 che1	truck
+开放	開放	kai1 fang4	to bloom
+开花	開花	kai1 hua1	to bloom
+开朗	開朗	kai1 lang3	spacious and well-lit
+开玩笑	開玩笑	kai1 wan2 xiao4	to play a joke
+看起来	看起來	kan4 qi3 lai2	seemingly
+可乐	可樂	ke3 le4	amusing
+可恶	可惡	ke3 wu4	repulsive
+课程	課程	ke4 cheng2	course
+课堂	課堂	ke4 tang2	classroom
+课文	課文	ke4 wen2	text
+客满	客滿	ke4 man3	to have a full house
+空间	空間	kong1 jian1	space
+空军	空軍	kong1 jun1	air force
+夸张	誇張	kua1 zhang1	to exaggerate
+宽	寬	kuan1	lenient
+况且	況且	kuang4 qie3	moreover
+困难	困難	kun4 nan2	difficult
+扩大	擴大	kuo4 da4	to expand
+来不及	來不及	lai2 bu4 ji2	there's not enough time (to do sth)
+来得及	來得及	lai2 de5 ji2	there's still time
+老实	老實	lao3 shi5	honest
+乐观	樂觀	le4 guan1	optimistic
+乐趣	樂趣	le4 qu4	delight
+泪	淚	lei4	tears
+类	類	lei4	kind
+离婚	離婚	li2 hun1	to divorce
+里边	裡邊	li3 bian1	inside
+理论	理論	li3 lun4	theory
+礼堂	禮堂	li3 tang2	assembly hall
+厉害	厲害	li4 hai5	difficult to deal with
+连	連	lian2	to link
+连续剧	連續劇	lian2 xu4 ju4	serialized drama
+恋爱	戀愛	lian4 ai4	(romantic) love
+灵魂	靈魂	ling2 hun2	soul
+零钱	零錢	ling2 qian2	change (of money)
+零用钱	零用錢	ling2 yong4 qian2	pocket money
+领导	領導	ling3 dao3	lead
+领域	領域	ling3 yu4	domain
+留学	留學	liu2 xue2	to study abroad
+留学生	留學生	liu2 xue2 sheng1	student studying abroad
+龙	龍	long2	dragon
+录取	錄取	lu4 qu3	to accept an applicant (prospective student, employee etc) who passes an entrance exam
+录音	錄音	lu4 yin1	to record (sound)
+露营	露營	lu4 ying2	to camp out
+轮胎	輪胎	lun2 tai1	tire
+律师	律師	lü4 shi1	lawyer
+马桶	馬桶	ma3 tong3	chamber pot
+码头	碼頭	ma3 tou5	dock
+蚂蚁	螞蟻	ma3 yi3	ant
+骂	罵	ma4	to scold
+满足	滿足	man3 zu2	to satisfy
+贸易	貿易	mao4 yi4	(commercial) trade
+没什么	沒什麼	mei2 shen2 me5	nothing
+没想到	沒想到	mei2 xiang3 dao4	didn't expect
+梦	夢	meng4	dream
+米饭	米飯	mi3 fan4	(cooked) rice
+免费	免費	mian3 fei4	free (of charge)
+面积	面積	mian4 ji1	area (of a floor, piece of land etc)
+面条	麵條	mian4 tiao2	noodles
+描写	描寫	miao2 xie3	to describe
+庙	廟	miao4	temple
+民国	民國	min2 guo2	Republic of China (1912-1949)
+名词	名詞	ming2 ci2	noun
+明显	明顯	ming2 xian3	clear
+摩托车	摩托車	mo2 tuo1 che1	motorbike
+木头	木頭	mu4 tou5	slow-witted
+那样	那樣	na4 yang4	that kind
+难怪	難怪	nan2 guai4	(it's) no wonder (that...)
+难看	難看	nan2 kan4	ugly
+脑子	腦子	nao3 zi5	brains
+闹钟	鬧鐘	nao4 zhong1	alarm clock
+内容	內容	nei4 rong2	content
+能够	能夠	neng2 gou4	to be capable of
+年龄	年齡	nian2 ling2	(a person's) age
+念书	念書	nian4 shu1	to read
+农业	農業	nong2 ye4	agriculture
+培养	培養	pei2 yang3	to cultivate
+批评	批評	pi1 ping2	to criticize
+皮带	皮帶	pi2 dai4	strap
+皮肤	皮膚	pi2 fu1	skin
+骗子	騙子	pian4 zi5	swindler
+品质	品質	pin3 zhi2	character
+平时	平時	ping2 shi2	ordinarily
+破坏	破壞	po4 huai4	destruction
+欺负	欺負	qi1 fu4	to bully
+其实	其實	qi2 shi2	actually
+期间	期間	qi2 jian1	period of time
+气温	氣溫	qi4 wen1	air temperature
+企业	企業	qi4 ye4	company
+签名	簽名	qian1 ming2	to sign (one's name with a pen etc)
+签证	簽證	qian1 zheng4	visa
+谦虚	謙虛	qian1 xu1	modest
+浅	淺	qian3	sound of moving water
+强盗	強盜	qiang2 dao4	to rob (with force)
+强调	強調	qiang2 diao4	to emphasize (a statement)
+抢	搶	qiang3	to fight over
+亲切	親切	qin1 qie4	amiable
+亲手	親手	qin1 shou3	personally
+亲眼	親眼	qin1 yan3	with one's own eyes
+亲自	親自	qin1 zi4	personally
+轻松	輕鬆	qing1 song1	light
+情况	情況	qing2 kuang4	circumstances
+请教	請教	qing3 jiao4	to ask for guidance
+请求	請求	qing3 qiu2	to request
+穷	窮	qiong2	poor
+球场	球場	qiu2 chang3	stadium
+球赛	球賽	qiu2 sai4	sports match
+球员	球員	qiu2 yuan2	sports club member
+缺点	缺點	que1 dian3	weak point
+却	卻	que4	but
+确定	確定	que4 ding4	definite
+确认	確認	que4 ren4	to confirm
+热狗	熱狗	re4 gou3	hot dog (loanword)
+热水	熱水	re4 shui3	hot water
+人间	人間	ren2 jian1	the human world
+人类	人類	ren2 lei4	humanity
+人们	人們	ren2 men5	people
+人数	人數	ren2 shu4	number of people
+认得	認得	ren4 de5	to recognize
+任务	任務	ren4 wu4	mission
+日记	日記	ri4 ji4	diary
+伞	傘	san3	umbrella
+杀	殺	sha1	to kill
+山区	山區	shan1 qu1	mountain area
+伤害	傷害	shang1 hai4	to injure
+商业	商業	shang1 ye4	business
+上当	上當	shang4 dang4	taken in (by sb's deceit)
+设备	設備	she4 bei4	equipment
+设计	設計	she4 ji4	plan
+身边	身邊	shen1 bian1	at one's side
+声调	聲調	sheng1 diao4	tone
+生产	生產	sheng1 chan3	to produce
+生动	生動	sheng1 dong4	vivid
+省钱	省錢	sheng3 qian2	to save money
+失恋	失戀	shi1 lian4	to lose one's love
+狮子	獅子	shi1 zi5	Leo (star sign)
+石头	石頭	shi2 tou5	stone
+时代	時代	shi2 dai4	Time, US weekly news magazine
+时刻	時刻	shi2 ke4	time
+实话	實話	shi2 hua4	truth
+实际	實際	shi2 ji4	reality
+实力	實力	shi2 li4	strength
+实行	實行	shi2 xing2	to implement
+实在	實在	shi2 zai4	really
+事实	事實	shi4 shi2	fact
+事业	事業	shi4 ye4	undertaking
+适应	適應	shi4 ying4	to adapt
+市长	市長	shi4 zhang3	mayor
+收获	收穫	shou1 huo4	to harvest
+收音机	收音機	shou1 yin1 ji1	radio
+手续	手續	shou3 xu4	procedure
+书包	書包	shu1 bao1	schoolbag
+书架	書架	shu1 jia4	bookshelf
+舒适	舒適	shu1 shi4	cozy
+数字	數字	shu4 zi4	numeral
+树木	樹木	shu4 mu4	tree
+帅	帥	shuai4	handsome
+水饺	水餃	shui3 jiao3	boiled dumpling
+水准	水準	shui3 zhun3	level (of achievement etc)
+睡着	睡著	shui4 zhao2	to fall asleep
+顺便	順便	shun4 bian4	conveniently
+顺利	順利	shun4 li4	smoothly
+说法	說法	shuo1 fa3	to expound Buddhist teachings
+说明	說明	shuo1 ming2	to explain
+寺庙	寺廟	si4 miao4	temple
+随便	隨便	sui2 bian4	as one wishes
+随时	隨時	sui2 shi2	at any time
+所谓	所謂	suo3 wei4	so-called
+它们	它們	ta1 men5	they (for inanimate objects)
+台风	颱風	tai2 feng1	hurricane
+态度	態度	tai4 du4	manner
+谈话	談話	tan2 hua4	talk
+讨厌	討厭	tao3 yan4	to dislike
+题材	題材	ti2 cai2	subject matter
+题目	題目	ti2 mu4	subject
+体会	體會	ti3 hui4	to know from experience
+体力	體力	ti3 li4	physical strength
+体贴	體貼	ti3 tie1	considerate (of other people's needs)
+体重	體重	ti3 zhong4	body weight
+甜点	甜點	tian2 dian3	dessert
+条件	條件	tiao2 jian4	condition
+挑战	挑戰	tiao3 zhan4	to challenge
+铁路	鐵路	tie3 lu4	railroad
+听见	聽見	ting1 jian4	to hear
+听力	聽力	ting1 li4	hearing
+听起来	聽起來	ting1 qi3 lai2	to sound like
+听众	聽眾	ting1 zhong4	audience
+通过	通過	tong1 guo4	by means of
+同时	同時	tong2 shi2	at the same time
+同样	同樣	tong2 yang4	same
+投资	投資	tou2 zi1	investment
+头痛	頭痛	tou2 tong4	to have a headache
+团体	團體	tuan2 ti3	group
+团圆	團圓	tuan2 yuan2	to have a reunion
+推荐	推薦	tui1 jian4	to recommend
+推销	推銷	tui1 xiao1	to market
+脱	脫	tuo1	to shed
+外边	外邊	wai4 bian1	outside
+外语	外語	wai4 yu3	foreign language
+万一	萬一	wan4 yi1	just in case
+网路	網路	wang3 lu4	network (computer, telecom)
+忘记	忘記	wang4 ji4	to forget
+维持	維持	wei2 chi2	to keep
+为主	為主	wei2 zhu3	to rely mainly on
+伟大	偉大	wei3 da4	huge
+未来	未來	wei4 lai2	future
+温柔	溫柔	wen1 rou2	gentle and soft
+文学	文學	wen2 xue2	literature
+稳定	穩定	wen3 ding4	steady
+问好	問好	wen4 hao3	to say hello to
+问候	問候	wen4 hou4	to give one's respects
+无法	無法	wu2 fa3	unable
+无论如何	無論如何	wu2 lun4 ru2 he2	whatever the case
+无穷	無窮	wu2 qiong2	endless
+无所谓	無所謂	wu2 suo3 wei4	to be indifferent
+误会	誤會	wu4 hui4	to misunderstand
+物价	物價	wu4 jia4	(commodity) prices
+牺牲	犧牲	xi1 sheng1	to sacrifice one's life
+喜爱	喜愛	xi3 ai4	to like
+细	細	xi4	thin or slender
+细心	細心	xi4 xin1	careful
+戏	戲	xi4	trick
+戏剧	戲劇	xi4 ju4	drama
+系统	系統	xi4 tong3	system
+下来	下來	xia4 lai5	to come down
+吓	嚇	xia4	to scare
+吓一跳	嚇一跳	xia4 yi2 tiao4	startled
+线	線	xian4	thread
+现代	現代	xian4 dai4	Hyundai, South Korean company
+现实	現實	xian4 shi2	reality
+现象	現象	xian4 xiang4	appearance
+相当	相當	xiang1 dang1	equivalent to
+相对	相對	xiang1 dui4	relatively
+相关	相關	xiang1 guan1	related
+详细	詳細	xiang2 xi4	detailed
+项	項	xiang4	back of neck
+相机	相機	xiang4 ji1	at the opportune moment
+相声	相聲	xiang4 sheng1	comic dialogue
+小组	小組	xiao3 zu3	group
+笑话	笑話	xiao4 hua4	joke
+孝顺	孝順	xiao4 shun4	filial piety
+协助	協助	xie2 zhu4	to provide assistance
+欣赏	欣賞	xin1 shang3	to appreciate
+兴奋	興奮	xing1 fen4	excited
+行动	行動	xing2 dong4	operation
+行为	行為	xing2 wei2	action
+醒来	醒來	xing3 lai2	to waken
+性别	性別	xing4 bie2	gender
+幸亏	幸虧	xing4 kui1	fortunately
+幸运	幸運	xing4 yun4	fortunate
+凶	兇	xiong1	terrible
+熊猫	熊貓	xiong2 mao1	panda
+选	選	xuan3	to choose
+选举	選舉	xuan3 ju3	to elect
+选择	選擇	xuan3 ze2	to select
+学会	學會	xue2 hui4	to learn
+学问	學問	xue2 wen4	learning
+寻找	尋找	xun2 zhao3	to seek
+训练	訓練	xun4 lian4	to train
+鸭	鴨	ya1	duck
+牙齿	牙齒	ya2 chi3	tooth
+烟火	煙火	yan1 huo3	smoke and fire
+严重	嚴重	yan2 zhong4	grave
+演讲	演講	yan3 jiang3	lecture
+演员	演員	yan3 yuan2	actor or actress
+眼泪	眼淚	yan3 lei4	tears
+阳光	陽光	yang2 guang1	sunshine
+样样	樣樣	yang4 yang4	all kinds
+邀请	邀請	yao1 qing3	to invite
+要紧	要緊	yao4 jin3	important
+页	頁	ye4	page
+夜里	夜裡	ye4 li5	during the night
+衣柜	衣櫃	yi1 gui4	wardrobe
+一块	一塊	yi1 kuai4	one block
+以来	以來	yi3 lai2	since (a previous event)
+以内	以內	yin3 ei4	within
+以为	以為	yi3 wei2	to think (i.e. to take it to be true that ...) (Usually there is an implication that the notion is mistaken – except when expressing one's own current opinion.)
+一般来说	一般來說	yi4 ban1 lai2 shuo1	generally speaking
+一连	一連	yi4 lian2	in a row
+一时	一時	yi4 shi2	a period of time
+意见	意見	yi4 jian4	idea
+意义	意義	yi4 yi4	sense
+阴	陰	yin1	overcast (weather)
+音响	音響	yin1 xiang3	sound
+营养	營養	ying2 yang3	nutrition
+拥有	擁有	yong3 you3	to have
+优点	優點	you1 dian3	merit
+优秀	優秀	you1 xiu4	outstanding
+邮票	郵票	you2 piao4	(postage) stamp
+游客	遊客	you2 ke4	traveler
+由于	由於	you2 yu2	due to
+有点儿	有點兒	you3 dian3 r5	slightly
+有钱	有錢	you3 qian2	well-off
+友谊	友誼	you3 yi4	companionship
+于是	於是	yu2 shi4	thereupon
+与	與	yu3	and
+预备	預備	yu4 bei4	to prepare
+预习	預習	yu4 xi2	to prepare a lesson
+员工	員工	yuan2 gong1	staff
+原谅	原諒	yuan2 liang4	to excuse
+愿望	願望	yuan4 wang4	desire
+约会	約會	yue1 hui4	appointment
+月饼	月餅	yue4 bing3	mooncake (esp. for the Mid-Autumn Festival)
+阅读	閱讀	yue4 du2	to read
+乐团	樂團	yue4 tuan2	band
+运气	運氣	yun4 qi4	luck (good or bad)
+在于	在於	zai4 yu2	to be in
+责任	責任	ze2 ren4	responsibility
+暂时	暫時	zhan4 shi2	temporary
+战争	戰爭	zhan4 zheng1	war
+长大	長大	zhang3 da4	to grow up
+障碍	障礙	zhan4 gai4	barrier
+找钱	找錢	zhao3 qian2	to give change
+哲学	哲學	zhe2 xue2	philosophy
+这下子	這下子	zhe4 xia4 zi5	this time
+这样	這樣	zhe4 yang4	this kind of
+这样子	這樣子	zhe4 yang4 zi5	so
+真实	真實	zhen1 shi2	true
+珍贵	珍貴	zhen1 gui4	precious
+整齐	整齊	zheng3 qi2	orderly
+正确	正確	zheng4 que4	correct
+证明	證明	zheng4 ming2	proof
+证书	證書	zheng4 shu1	credentials
+知识	知識	zhi1 shi4	knowledge
+之后	之後	zhi1 hou4	afterwards
+之间	之間	zhi1 jian1	between
+职员	職員	zhi2 yuan2	office worker
+至于	至於	zhi4 yu2	as for
+终于	終於	zhong1 yu2	at last
+重点	重點	zhong4 dian3	to recount (e.g. results of election)
+重视	重視	zhong4 shi4	to attach importance to sth
+周围	周圍	zhou1 wei2	surroundings
+主动	主動	zhu3 dong4	to take the initiative
+主妇	主婦	zhu3 fu4	housewife
+主题	主題	zhu3 ti2	theme
+专心	專心	zhuan1 xin1	to concentrate
+专业	專業	zhuan1 ye4	specialty
+状态	狀態	zhuang4 tai4	state of affairs
+准时	準時	zhun3 shi2	on time
+资料	資料	zi1 liao4	material
+资源	資源	zi1 yuan2	natural resource (such as water or minerals)
+仔细	仔細	zi3 xi4	careful
+自从	自從	zi4 cong2	since (a time)
+自动	自動	zi4 dong4	automatic
+自杀	自殺	zi4 sha1	to kill oneself
+总而言之	總而言之	zong3 er2 yan2 zhi1	in short
+总算	總算	zong3 suan4	at long last
+总统	總統	zong3 tong3	president (of a country)
+总之	總之	zong3 zhi1	in a word
+做梦	做夢	zuo4 meng4	to dream

--- a/cordova-build-override/www/assets/lists/tocfl6.list
+++ b/cordova-build-override/www/assets/lists/tocfl6.list
@@ -1,0 +1,1089 @@
+哎哟	哎喲	ai1 yao1	hey
+爱好	愛好	ai4 hao4	to like
+爱护	愛護	ai4 hu4	to cherish
+爱人	愛人	ai4 ren2	spouse (PRC)
+安装	安裝	an1 zhuang1	to install
+按时	按時	an4 shi2	on time
+肮脏	骯髒	ang1 zhang1	dirty
+罢工	罷工	ba4 gong1	a strike
+罢了	罷了	ba4 le5	a modal particle indicating (that's all, only, nothing much)
+摆脱	擺脫	bai3 tuo1	to break away from
+拜访	拜訪	bai4 fang3	to pay a visit
+拜托	拜託	bai4 tuo1	to request sb to do sth
+班长	班長	ban1 zhang3	class monitor
+搬运	搬運	ban1 yun4	freight
+半数	半數	ban4 shu4	half the number
+办公	辦公	ban4 gong1	to handle official business
+办事	辦事	ban4 shi4	to handle (affairs)
+包装	包裝	bao1 zhuang1	to pack
+保卫	保衛	bao3 wei4	to defend
+宝宝	寶寶	bao3 bao5	darling
+报仇	報仇	bao4 chou2	to take revenge
+报答	報答	bao4 da2	to repay
+报导	報導	bao4 dao3	to report (in the media)
+报到	報到	bao4 dao4	to report for duty
+报警	報警	bao4 jing3	to sound an alarm
+报社	報社	bao4 she4	newspaper (i.e. a company)
+悲剧	悲劇	bei1 ju4	tragedy
+本领	本領	ben3 ling3	skill
+笔记	筆記	bi3 ji4	to take down (in writing)
+笔试	筆試	bi3 shi4	written examination
+闭	閉	bi4	to close
+编	編	bian1	to weave
+变动	變動	bian4 dong4	to change
+标题	標題	biao1 ti2	title
+标志	標誌	biao1 zhi4	sign
+表扬	表揚	biao3 yang2	to praise
+并且	並且	bing4 qie3	and
+拨	撥	bo1	to push aside with the hand, foot, a stick etc
+波动	波動	bo1 dong4	to undulate
+补	補	bu3	to repair
+补偿	補償	bu3 chang2	to compensate
+补充	補充	bu3 chong1	to replenish
+补课	補課	bu3 ke4	to make up missed lesson
+补习	補習	bu3 xi2	to take extra lessons in a cram school or with a private tutor
+补助	補助	bu3 zhu4	to subsidize
+不当	不當	bu4 dang4	unsuitable
+不敢当	不敢當	bu4 gan3 dang1	lit. I dare not (accept the honor); fig. I don't deserve your praise
+不顾	不顧	bu4 gu4	in spite of
+不见得	不見得	bu4 jian4 de5	not necessarily
+不仅	不僅	bu4 jin3	not only (this one)
+不许	不許	bu4 xu3	not to allow
+部队	部隊	bu4 dui4	army
+部长	部長	bu4 zhang3	head of a (government etc) department
+财产	財產	cai2 chan3	property
+财富	財富	cai2 fu4	wealth
+裁员	裁員	cai2 yuan2	to cut staff
+采购	採購	cai3 gou4	to procure (for an enterprise etc)
+参与	參與	can1 yu4	to participate (in sth)
+蚕	蠶	can2	silkworm
+惭愧	慚愧	can2 kui4	ashamed
+惨	慘	can3	miserable
+仓库	倉庫	cang1 ku4	depot
+册	冊	ce4	book
+测量	測量	ce4 liang2	survey
+测试	測試	ce4 shi4	to test (machinery etc)
+测验	測驗	ce4 yan4	test
+差错	差錯	cha1 cuo4	mistake
+插图	插圖	cha1 tu2	illustration
+茶馆	茶館	cha2 guan3	teahouse
+茶会	茶會	cha2 hui4	tea party
+茶叶	茶葉	cha2 ye4	tea
+产量	產量	chan3 liang4	output
+产业	產業	chan3 ye4	industry
+常识	常識	chang2 shi4	common sense
+长处	長處	chang2 chu4	good aspects
+长度	長度	chang2 du4	length
+长方形	長方形	chang2 fang1 xing2	rectangle
+长久	長久	chang2 jiu3	(for a) long time
+长途	長途	chang2 tu2	long distance
+场地	場地	chang3 di4	space
+场合	場合	chang3 he2	situation
+场所	場所	chang3 suo3	location
+厂商	廠商	chang3 shang1	manufacturer
+钞票	鈔票	chao1 piao4	paper money
+吵闹	吵鬧	chao3 nao4	noisy
+车票	車票	che1 piao4	ticket (for a bus or train)
+陈列	陳列	chen2 lie4	to display
+称	稱	cheng1	to fit
+撑	撐	cheng1	to support
+成为	成為	cheng2 wei2	to become
+成语	成語	cheng2 yu3	Chinese set expression, typically of 4 characters, often alluding to a story or historical quotation
+诚恳	誠懇	cheng2 ken3	sincere
+诚意	誠意	cheng2 yi4	sincerity
+呈现	呈現	cheng2 xian4	to appear
+吃亏	吃虧	chi1 kui1	to suffer losses
+迟早	遲早	chi2 zao3	sooner or later
+冲	沖, 衝	chong1	(of water) to dash against
+充满	充滿	chong1 man3	full of
+抽屉	抽屜	chou1 ti5	drawer
+出产	出產	chu1 chan3	to produce (by natural growth, or by manufacture, mining etc)
+初级	初級	chu1 ji2	junior
+储存	儲存	chu2 cun2	stockpile
+储蓄	儲蓄	chu2 xu4	to deposit money
+处罚	處罰	chu3 fa2	to penalize
+处处	處處	chu4 chu4	everywhere
+传播	傳播	chuan2 bo4	to disseminate
+传达	傳達	chuan2 da2	to pass on
+传单	傳單	chuan2 dan1	leaflet
+传染	傳染	chuan2 ran3	to infect
+传说	傳說	chuan2 shuo1	legend
+传送	傳送	chuan2 song4	to convey
+床单	床單	chuang2 dan1	bed sheet
+闯	闖	chuang3	to rush
+创作	創作	chuang4 zuo4	to create
+磁带	磁帶	ci2 dai4	magnetic tape
+词典	詞典	ci2 dian3	dictionary (of Chinese compound words)
+词汇	詞彙	ci2 hui4	vocabulary
+辞职	辭職	ci2 zhi2	to resign
+次数	次數	ci4 shu4	number of times
+从此	從此	cong2 ci3	from now on
+从没	從沒	cong2 mei2	never (in the past)
+从事	從事	cong2 shi4	to go for
+凑	湊	cou4	to gather together, pool or collect
+促进	促進	cu4 jin4	to promote (an idea or cause)
+错过	錯過	cuo4 guo4	to miss (train, opportunity etc)
+错字	錯字	cuo4 zi4	incorrect character
+达到	達到	da2 dao4	to reach
+打断	打斷	da3 duan4	to interrupt
+打扰	打擾	da3 rao3	to disturb
+打针	打針	da3 zhen1	to give or have an injection
+大胆	大膽	da4 dan3	brazen
+大脑	大腦	dan4 ao3	brain
+大众	大眾	da4 zhong4	Volkswagen (automobile manufacturer)
+代沟	代溝	dai4 gou1	generation gap
+代价	代價	dai4 jia4	price
+带动	帶動	dai4 dong4	to spur
+带路	帶路	dai4 lu4	to lead the way
+带子	帶子	dai4 zi5	belt
+贷款	貸款	dai4 kuan3	a loan
+单调	單調	dan1 diao4	monotonous
+单位	單位	dan1 wei4	unit (of measure)
+单子	單子	dan1 zi5	the only son of a family
+担保	擔保	dan1 bao3	to guarantee
+耽误	耽誤	dan1 wu4	to delay
+胆量	膽量	dan3 liang4	courage
+胆小	膽小	dan3 xiao3	cowardice
+蛋白质	蛋白質	dan4 bai2 zhi2	protein
+诞生	誕生	dan4 sheng1	to be born
+当初	當初	dang1 chu1	at that time
+当时	當時	dang1 shi2	then
+当选	當選	dang1 xuan3	to be elected
+挡	擋	dang3	to resist
+档案	檔案	dan3 gan4	file
+导游	導遊	dao3 you2	tour guide
+到达	到達	dao4 da2	to reach
+得奖	得獎	de2 jiang3	to win a prize
+登记	登記	deng1 ji4	to register (one's name)
+等级	等級	deng3 ji2	grade
+等于	等於	deng3 yu2	to equal
+的确	的確	di2 que4	really
+递	遞	di4	to hand over
+典礼	典禮	dian3 li3	celebration
+点燃	點燃	dian3 ran2	to ignite
+点头	點頭	dian3 tou2	to nod
+垫	墊	dian4	pad
+电报	電報	dian4 bao4	telegram
+电动	電動	dian4 dong4	electric-powered
+电扇	電扇	dian4 shan4	electric fan
+电线	電線	dian4 xian4	wire
+电子	電子	dian4 zi3	electronic
+钓	釣	diao4	to fish with a hook and bait
+顶	頂	ding3	apex
+订婚	訂婚	ding4 hun1	to get engaged
+订位	訂位	ding4 wei4	to reserve a seat
+丢脸	丟臉	diu1 lian3	to lose face
+丢人	丟人	diu1 ren2	to lose face
+冻	凍	dong4	to freeze
+栋	棟	dong4	classifier for houses or buildings
+动不动	動不動	dong4 bu5 dong4	apt to happen (usually of sth undesirable)
+动词	動詞	dong4 ci2	verb
+动人	動人	dong4 ren2	touching
+动身	動身	dong4 shen1	to go on a journey
+动手	動手	dong4 shou3	to set about (a task)
+动作	動作	dong4 zuo4	movement
+斗争	鬥爭	dou4 zheng1	a struggle
+独立	獨立	du2 li4	independent
+独自	獨自	du2 zi4	alone
+赌	賭	du3	to bet
+度过	度過	du4 guo4	to pass
+锻炼	鍛鍊	duan4 lian4	to toughen
+队员	隊員	dui4 yuan2	team member
+对岸	對岸	dui4 an4	opposite bank (of a body of water)
+对策	對策	dui4 ce4	countermeasure for dealing with a situation
+对待	對待	dui4 dai4	to treat
+对付	對付	dui4 fu4	to handle
+对抗	對抗	dui4 kang4	to withstand
+对立	對立	dui4 li4	to oppose
+对于	對於	dui4 yu2	regarding
+吨	噸	dun4	ton (loanword)
+多数	多數	duo1 shu4	majority
+多谢	多謝	duo1 xie4	many thanks
+夺	奪	duo2	to seize
+鹅	鵝	e2	goose
+恶劣	惡劣	e4 lie4	vile
+发动	發動	fa1 dong4	to start
+发抖	發抖	fa1 dou3	to tremble
+发起	發起	fa1 qi3	to originate
+发射	發射	fa1 she4	to shoot (a projectile)
+发行	發行	fa1 xing2	to publish
+发言	發言	fa1 yan2	to make a speech
+发扬	發揚	fa1 yang2	to develop
+发音	發音	fa1 yin1	to pronounce
+发展	發展	fa1 zhan3	development
+发型	髮型	fa3 xing2	hairstyle
+繁荣	繁榮	fan2 rong2	prosperous
+反对	反對	fan3 dui4	to fight against
+反复	反覆	fan3 fu4	repeatedly
+反问	反問	fan3 wen4	to ask (a question) in reply
+犯错	犯錯	fan4 cuo4	to err
+放弃	放棄	fang4 qi4	to renounce
+放学	放學	fang4 xue2	to dismiss students at the end of the school day
+废话	廢話	fei4 hua4	nonsense
+废气	廢氣	fei4 qi4	exhaust gas
+废水	廢水	fei4 shui3	waste water
+废物	廢物	fei4 wu4	rubbish
+分别	分別	fen1 bie2	to part or leave each other
+分数	分數	fen1 shu4	(exam) grade
+纷纷	紛紛	fen1 fen1	one after another
+粉笔	粉筆	fen3 bi3	chalk
+奋斗	奮鬥	fen4 dou4	to strive
+愤怒	憤怒	fen4 nu4	angry
+风气	風氣	feng1 qi4	general mood
+风趣	風趣	feng1 qu4	charm
+风险	風險	feng1 xian3	risk
+疯	瘋	feng1	insane
+疯狂	瘋狂	feng1 kuang2	crazy
+疯子	瘋子	feng1 zi5	madman
+缝	縫	feng2	to sew
+讽刺	諷刺	feng4 ci4	to satirize
+否认	否認	fou3 ren4	to declare to be untrue
+符号	符號	fu2 hao4	symbol
+辅导	輔導	fu3 dao3	to give guidance
+妇女	婦女	fu5	woman
+复杂	複雜	fu4 za2	complicated
+复制	複製	fu4 zhi4	to duplicate
+干杯	乾杯	gan1 bei1	to drink a toast
+干脆	乾脆	gan1 cui4	straightforward
+赶紧	趕緊	gan3 jin3	hurriedly
+干部	幹部	gan4 bu4	cadre
+干嘛	幹嘛	gan4 ma5	what are you doing?
+干什么	幹什麼	gan4 shen2 me5	what are you doing?
+钢笔	鋼筆	gang1 bi3	fountain pen
+刚好	剛好	gang1 hao3	just
+港币	港幣	gang3 bi4	Hong Kong currency
+高贵	高貴	gao1 gui4	grandeur
+高级	高級	gao1 ji2	high level
+告辞	告辭	gao4 ci2	to say goodbye
+搁	擱	ge1	to place
+歌剧	歌劇	ge1 ju4	Western opera
+各行各业	各行各業	ge4 hang2 ge4 ye4	every trade
+个别	個別	ge4 bie2	individual
+个性	個性	ge4 xing4	individuality
+工会	工會	gong1 hui4	labor union
+工钱	工錢	gong1 qian2	salary
+工资	工資	gong1 zi1	wages
+公开	公開	gong1 kai1	public
+供应	供應	gong1 ying4	to supply
+构成	構成	gou4 cheng2	to constitute
+构造	構造	gou4 zao4	structure
+孤单	孤單	gu1 dan1	lone
+估计	估計	gu1 ji4	to estimate
+鼓励	鼓勵	gu3 li4	to encourage
+骨头	骨頭	gu2 tou5	bone
+顾问	顧問	gu4 wen4	adviser
+故乡	故鄉	gu4 xiang1	home
+挂号信	掛號信	gua4 hao4 xin4	registered letter
+官员	官員	guan1 yuan2	official (in an organization or government)
+关键	關鍵	guan1 jian4	crucial point
+关上	關上	guan1 shang4	to close (a door)
+关于	關於	guan1 yu2	pertaining to
+观光	觀光	guan1 guang1	to tour
+惯例	慣例	guan4 li4	convention
+冠军	冠軍	guan4 jun1	champion
+罐头	罐頭	guan4 tou5	tin
+光临	光臨	guang1 lin2	(formal) to honor with one's presence
+光荣	光榮	guang1 rong2	honor and glory
+光线	光線	guang1 xian4	light ray
+广大	廣大	guang3 da4	(of an area) vast or extensive
+广泛	廣泛	guang3 fan4	extensive
+广阔	廣闊	guang3 kuo4	wide
+规定	規定	gui1 ding4	provision
+规律	規律	gui1 lü4	rule (e.g. of science)
+规则	規則	gui1 ze2	rule
+柜台	櫃臺	gui4 tai2	variant of 櫃檯|柜台[gui4 tai2]
+贵族	貴族	gui4 zu2	lord
+滚	滾	gun3	to boil
+锅	鍋	guo1	pot
+国会	國會	guo2 hui4	parliament
+国籍	國籍	guo2 ji2	nationality
+国际	國際	guo2 ji4	international
+国立	國立	guo2 li4	national
+国旗	國旗	guo2 qi2	flag (of a country)
+国小	國小	guo2 xiao3	elementary school (Taiwan)
+国中	國中	guo2 zhong1	junior high school (Taiwan)
+过程	過程	guo4 cheng2	course of events
+过度	過度	guo4 du4	excessive
+过渡	過渡	guo4 du4	to cross over (by ferry)
+过节	過節	guo4 jie2	to celebrate a festival
+过滤	過濾	guo4 lü4	to filter
+过期	過期	guo4 qi2	to be overdue
+过世	過世	guo4 shi4	to die
+还不如	還不如	hai2 bu4 ru2	to be better off ...
+还有	還有	hai2 you3	furthermore
+海关	海關	hai3 guan1	customs (i.e. border crossing inspection)
+海军	海軍	hai3 jun1	navy
+海峡	海峽	hai3 xia2	channel
+海鲜	海鮮	hai3 xian1	seafood
+害处	害處	hai4 chu4	damage
+行业	行業	hang2 ye4	industry
+毫无	毫無	hao2 wu2	not in the least
+号召	號召	hao4 zhao4	to call
+合不来	合不來	he2 bu5 lai2	unable to get along together
+合得来	合得來	he2 de5 lai2	to get along well
+合适	合適	he2 shi4	suitable
+和气	和氣	he2 qi4	friendly
+何况	何況	he2 kuang4	let alone
+痕迹	痕跡	hen2 ji1	vestige
+横	橫	heng2	horizontal
+喉咙	喉嚨	hou2 long5	throat
+后代	後代	hou4 dai4	descendant
+后方	後方	hou4 fang1	the rear
+后果	後果	hou4 guo3	consequences
+后悔	後悔	hou4 hui3	to regret
+后年	後年	hou4 nian2	the year after next
+后头	後頭	hou4 tou5	behind
+后退	後退	hou4 tui4	to recoil
+后院	後院	hou4 yuan4	rear court
+忽视	忽視	hu1 shi4	to neglect
+胡子	鬍子	hu2 zi5	beard
+户	戶	hu4	a household
+户外	戶外	hu4 wai4	outdoor
+花费	花費	hua1 fei4	expense
+华侨	華僑	hua2 qiao2	overseas Chinese
+华人	華人	hua2 ren2	ethnic Chinese person or people
+化学	化學	hua4 xue2	chemistry
+化妆	化妝	hua4 zhuang1	to put on makeup
+化装	化裝	hua4 zhuang1	(of actors) to make up
+怀念	懷念	huai2 nian4	to cherish the memory of
+怀孕	懷孕	huai2 yun4	pregnant
+坏蛋	壞蛋	huai4 dan4	bad egg
+欢呼	歡呼	huan1 hu1	to cheer for
+欢乐	歡樂	huan1 le4	gaiety
+欢喜	歡喜	huan1 xi3	happy
+缓和	緩和	huan3 he2	to ease (tension)
+缓慢	緩慢	huan3 man4	slow
+黄豆	黃豆	huang2 dou4	soybean
+黄昏	黃昏	huang2 hun1	dusk
+回电	回電	hui2 dian4	to reply to a telegram
+回头	回頭	hui2 tou2	to turn round
+回忆	回憶	hui2 yi4	to recall
+汇款	匯款	hui4 kuan3	to remit money
+会员	會員	hui4 yuan2	member
+活该	活該	huo2 gai1	(coll.) serve sb right
+活泼	活潑	huo2 po1	lively
+活跃	活躍	huo2 yue4	active
+火灾	火災	huo3 zai1	fire (that burns buildings etc)
+货物	貨物	huo4 wu4	goods
+获得	獲得	huo4 de2	to obtain
+几乎	幾乎	ji1 hu1	almost
+机构	機構	ji1 gou4	mechanism
+机关	機關	ji1 guan1	mechanism
+机票	機票	ji1 piao4	air ticket
+机械	機械	ji1 xie4	machine
+及时	及時	ji2 shi2	in time
+即将	即將	ji2 jiang1	on the eve of
+极其	極其	ji2 qi2	extremely
+集邮	集郵	ji2 you2	stamp collecting
+技术	技術	ji4 shu4	technology
+计算	計算	ji4 suan4	to count
+计较	計較	ji4 jiao4	to bother about
+记性	記性	ji4 xing4	memory (ability to retain information)
+记载	記載	ji4 zai4	to write down
+记住	記住	ji4 zhu4	to remember
+夹	夾	jia2	to press from either side
+驾驶	駕駛	jia4 shi3	to pilot (ship, airplane etc)
+尖锐	尖銳	jian1 rui4	sharp
+坚定	堅定	jian1 ding4	firm
+坚决	堅決	jian1 jue2	firm
+监视	監視	jian1 shi4	to monitor
+监狱	監獄	jian1 yu4	prison
+拣	揀	jian3	to choose
+捡	撿	jian3	to pick up
+检验	檢驗	jian3 yan4	to inspect
+建国	建國	jian4 guo2	to found a country
+建筑	建築	jian4 zhu2	to construct
+渐渐	漸漸	jian4 jian4	gradually
+间接	間接	jian4 jie1	indirect
+键盘	鍵盤	jian4 pan2	keyboard
+将要	將要	jiang1 yao4	will
+奖金	獎金	jiang3 jin1	premium
+奖品	獎品	jiang3 pin3	award
+降价	降價	jiang4 jia4	to cut the price
+浇	澆	jiao1	to pour liquid
+交换	交換	jiao1 huan4	to exchange
+交际	交際	jiao1 ji4	communication
+缴	繳	jiao3	to hand in
+脚步	腳步	jiao3 bu4	footstep
+教会	教會	jiao4 hui4	to show
+教学	教學	jiao4 xue2	to teach
+接见	接見	jie1 jian4	to receive sb
+街头	街頭	jie1 tou2	street
+阶段	階段	jie1 duan4	stage
+节省	節省	jie2 sheng3	saving
+节约	節約	jie2 yue1	to economize
+结构	結構	jie2 gou4	structure
+结合	結合	jie2 he2	to combine
+结论	結論	jie2 lun4	conclusion
+结算	結算	jie2 suan4	to settle a bill
+结帐	結帳	jie2 zhang4	to pay the bill
+届	屆	jie4	to arrive at (place or time)
+界线	界線	jie4 xian4	limits
+今后	今後	jin1 hou4	hereafter
+金额	金額	jin1 e2	sum of money
+金属	金屬	jin1 shu3	metal
+尽量	儘量, 盡量	jin3 liang4 jin4 liang4	as much as possible
+紧急	緊急	jin3 ji2	urgent
+仅仅	僅僅	jin3 jin3	barely
+近来	近來	jin4 lai2	recently
+近视	近視	jin4 shi4	shortsighted
+尽力	盡力	jin4 li4	to strive one's hardest
+进入	進入	jin4 ru4	to enter
+进口	進口	jin4 kou3	to import
+精细	精細	jing1 xi4	fine
+经济	經濟	jing1 ji4	economy
+经历	經歷	jing1 li4	experience
+经营	經營	jing1 ying2	to engage in (business etc)
+京剧	京劇	jing1 ju4	Beijing opera
+惊人	驚人	jing1 ren2	astonishing
+敬爱	敬愛	jin4 gai4	respect and love
+敬礼	敬禮	jing4 li3	to salute
+净化	淨化	jing4 hua4	to purify
+竞争	競爭	jing4 zheng1	to compete
+纠正	糾正	jiu1 zheng4	to correct
+酒会	酒會	jiu3 hui4	drinking party
+就是说	就是說	jiu4 shi4 shuo1	in other words
+就业	就業	jiu4 ye4	to get a job
+具备	具備	ju4 bei4	to possess
+具体	具體	ju4 ti3	concrete
+俱乐部	俱樂部	ju4 le4 bu4	club (the organisation or its premises) (loanword)
+剧场	劇場	ju4 chang3	theater
+剧烈	劇烈	ju4 lie4	violent
+剧院	劇院	ju4 yuan4	theater
+据说	據說	ju4 shuo1	it is said that
+卷	捲	juan3	to roll (up)
+决心	決心	jue2 xin1	determination
+绝不	絕不	jue2 bu4	in no way
+绝大部分	絕大部分	jue2 da4 bu4 fen4	overwhelming majority
+觉悟	覺悟	jue2 wu4	to come to understand
+军事	軍事	jun1 shi4	military affairs
+开除	開除	kai1 chu2	to expel
+开刀	開刀	kai1 dao1	(of a surgeon) to perform an operation
+开发	開發	kai1 fa1	to exploit (a resource)
+开户	開戶	kai1 hu4	to open an account (bank etc)
+开课	開課	kai1 ke4	school begins
+开明	開明	kai1 ming2	enlightened
+开设	開設	kai1 she4	to offer (goods or services)
+开拓	開拓	kai1 tuo4	to break new ground (for agriculture)
+开演	開演	kai1 yan3	(of a play, movie etc) to begin
+看来	看來	kan4 lai2	apparently
+看样子	看樣子	kan4 yang4 zi5	it seems
+抗议	抗議	kang4 yi4	to protest
+考虑	考慮	kao3 lü4	to think over
+颗	顆	ke1	classifier for small spheres, pearls, corn grains, teeth, hearts, satellites etc
+客观	客觀	ke4 guan1	objective
+客户	客戶	ke4 hu4	client
+课外	課外	ke4 wai4	extracurricular
+口号	口號	kou3 hao4	slogan
+口红	口紅	kou3 hong2	lipstick
+口气	口氣	kou3 qi4	tone of voice
+口试	口試	kou3 shi4	oral examination
+口语	口語	kou3 yu3	colloquial speech
+夸奖	誇獎	kua1 jiang3	to praise
+会计	會計	kuai4 ji4	accountant
+宽度	寬度	kuan1 du4	width
+蜡烛	蠟燭	la4 zhu2	candle
+来回	來回	lai2 hui2	to make a round trip
+来临	來臨	lai2 lin2	to approach
+来往	來往	lai2 wang3	to come and go
+来信	來信	lai2 xin4	incoming letter
+来源	來源	lai2 yuan2	source (of information etc)
+来自	來自	lai2 zi4	to come from (a place)
+篮子	籃子	lan2 zi5	basket
+懒	懶	lan3	lazy
+懒得	懶得	lan3 de5	not to feel like (doing sth)
+烂	爛	lan4	soft
+滥用	濫用	lan4 yong4	to misuse
+浪费	浪費	lang4 fei4	to waste
+捞	撈	lao1	to fish up
+牢骚	牢騷	lao2 sao1	discontent
+劳动	勞動	lao2 dong4	work
+劳工	勞工	lao2 gong1	labor
+劳力	勞力	lao2 li4	labor
+唠叨	嘮叨	lao2 dao5	to prattle
+老板娘	老闆娘	lao3 ban3 niang2	female proprietor
+老实说	老實說	lao3 shi2 shuo1	honestly speaking
+乐意	樂意	le4 yi4	to be willing to do sth
+类似	類似	lei4 si4	similar
+冷静	冷靜	leng3 jing4	calm
+冷饮	冷飲	leng3 yin3	cold drink
+礼品	禮品	li3 pin3	gift
+力气	力氣	li4 qi5	strength
+立场	立場	li4 chang3	position
+利润	利潤	li4 run4	profits
+联合	聯合	lian2 he2	to combine
+联合国	聯合國	lian2 he2 guo2	United Nations
+连接	連接	lian2 jie1	to link
+连忙	連忙	lian2 mang2	promptly
+连续	連續	lian2 xu4	continuous
+脸色	臉色	lian3 se4	complexion
+粮食	糧食	liang2 shi2	foodstuff
+俩	倆	liang3	two (colloquial equivalent of 兩個|两个)
+谅解	諒解	liang4 jie3	to understand
+临时	臨時	lin2 shi2	as the time draws near
+灵活	靈活	ling2 huo2	flexible
+领带	領帶	ling3 dai4	necktie
+领土	領土	ling3 tu3	territory
+领先	領先	ling3 xian1	to lead
+领袖	領袖	ling3 xiu4	leader
+流动	流動	liu2 dong4	to flow
+喽	嘍	lou2	subordinates in gang of bandits
+搂	摟	lou3	to draw towards oneself
+路灯	路燈	lu4 deng1	street lamp
+路线	路線	lu4 xian4	itinerary
+陆军	陸軍	lu4 jun1	army
+陆续	陸續	lu4 xu4	in turn
+录用	錄用	lu4 yong4	to hire (an employee)
+轮船	輪船	lun2 chuan2	steamship
+轮流	輪流	lun2 liu2	to alternate
+轮子	輪子	lun2 zi5	wheel
+论文	論文	lun4 wen2	paper
+落后	落後	luo4 hou4	to fall behind
+落实	落實	luo4 shi2	practical
+绿豆	綠豆	lü4 dou4	mung bean
+马虎	馬虎	ma3 hu5	careless
+买单	買單	mai3 dan1	to pay the restaurant bill
+买卖	買賣	mai3 mai4	buying and selling
+馒头	饅頭	man2 tou5	steamed roll
+漫画	漫畫	man4 hua4	caricature
+美观	美觀	mei3 guan1	pleasing to the eye
+门票	門票	men2 piao4	ticket (for theater, cinema etc)
+门诊	門診	men2 zhen3	outpatient service
+梦想	夢想	meng4 xiang3	(fig.) to dream of
+勉强	勉強	mian3 qiang3	to do with difficulty
+面对	面對	mian4 dui4	to confront
+面临	面臨	mian4 lin2	to face sth
+面粉	麵粉	mian4 fen3	flour
+灭亡	滅亡	mie4 wang2	to be destroyed
+民间	民間	min2 jian1	among the people
+民谣	民謠	min2 yao2	ballad
+民众	民眾	min2 zhong4	populace
+名称	名稱	ming2 cheng1	name (of a thing)
+名单	名單	ming2 dan1	list (of names)
+明确	明確	ming2 que4	clear-cut
+命运	命運	ming4 yun4	fate
+模样	模樣	mo2 yang4	look
+目标	目標	mu4 biao1	target
+目录	目錄	mu4 lu4	catalog
+难道	難道	nan2 dao4	don't tell me ...
+难得	難得	nan2 de2	seldom
+难受	難受	nan2 shou4	to feel unwell
+难以	難以	nan2 yi3	hard to (predict, imagine etc)
+脑袋	腦袋	nao3 dai5	head
+脑筋	腦筋	nao3 jin1	brains
+闹区	鬧區	nao4 qu1	downtown
+内部	內部	nei4 bu4	interior
+内地	內地	nei4 di4	mainland China (PRC excluding Hong Kong and Macau, but including islands such as Hainan)
+内行	內行	nei4 hang2	expert
+内科	內科	nei4 ke1	internal medicine
+能干	能幹	neng2 gan4	capable
+宁可	寧可	ning2 ke3	preferably
+宁愿	寧願	ning2 yuan4	would rather
+农场	農場	nong2 chang3	farm
+农产品	農產品	nong2 chan3 pin3	agricultural produce
+农村	農村	nong2 cun1	rural area
+农民	農民	nong2 min2	peasant
+农药	農藥	nong2 yao4	agricultural chemical
+浓	濃	nong2	concentrated
+浓厚	濃厚	nong2 hou4	dense
+暖气	暖氣	nuan3 qi4	central heating
+判断	判斷	pan4 duan4	to judge
+炮	砲	pao4	variant of 炮[pao4]
+赔	賠	pei2	to compensate for loss
+赔偿	賠償	pei2 chang2	to compensate
+喷	噴	pen1	to puff
+膨胀	膨脹	peng2 zhang4	to expand
+碰见	碰見	peng4 jian4	to run into
+疲劳	疲勞	pi2 lao2	fatigue
+脾气	脾氣	pi2 qi5	character
+飘	飄	piao1	to float
+贫穷	貧窮	pin2 qiong2	poor
+聘请	聘請	pin4 qing3	to engage
+凭	憑	ping2	to lean against
+平静	平靜	ping2 jing4	tranquil
+颇	頗	po3	Taiwan pr. [Po3]
+破烂	破爛	po4 lan4	worn-out
+扑	撲	pu1	to throw oneself at
+扑灭	撲滅	pu1 mie4	to eradicate
+铺	鋪	pu1	to spread
+普通话	普通話	pu3 tong1 hua4	Mandarin (common language)
+欺骗	欺騙	qi1 pian4	to deceive
+其余	其餘	qi2 yu2	the rest
+齐全	齊全	qi2 quan2	complete
+歧视	歧視	qi2 shi4	to discriminate against
+企图	企圖	qi4 tu2	to attempt
+气氛	氣氛	qi4 fen1	atmosphere
+气愤	氣憤	qi4 fen4	indignant
+气候	氣候	qi4 hou4	climate
+气味	氣味	qi4 wei4	odor
+气息	氣息	qi4 xi2	breath
+气象	氣象	qi4 xiang4	meteorological feature
+千万	千萬	qian1 wan4	ten million
+牵	牽	qian1	to lead along
+迁	遷	qian1	to move
+签订	簽訂	qian1 ding4	to agree to and sign (a treaty etc)
+签约	簽約	qian1 yue1	to sign a contract or agreement
+签字	簽字	qian1 zi4	to sign (one's name)
+前进	前進	qian2 jin4	to go forward
+前头	前頭	qian2 tou5	in front
+枪	槍	qiang1	gun
+强大	強大	qiang2 da4	large
+强度	強度	qiang2 du4	strength
+强烈	強烈	qiang2 lie4	intense
+墙壁	牆壁	qiang2 bi4	wall
+强迫	強迫	qiang3 po4	to compel
+抢救	搶救	qiang3 jiu4	to rescue
+亲爱	親愛	qin1 ai4	dear
+亲口	親口	qin1 kou3	one's own mouth
+亲戚	親戚	qin1 qi1	a relative (i.e. family relation)
+亲人	親人	qin1 ren2	one's close relatives
+勤劳	勤勞	qin2 lao2	hardworking
+寝室	寢室	qin3 shi4	bedroom
+轻伤	輕傷	qing1 shang1	lightly wounded
+轻视	輕視	qing1 shi4	contempt
+倾向	傾向	qing1 xiang4	trend
+情书	情書	qing2 shu1	love letter
+情绪	情緒	qing2 xu4	mood
+球队	球隊	qiu2 dui4	sports team (basketball, soccer, football etc)
+区别	區別	qu1 bie2	difference
+区域	區域	qu1 yu4	area
+全体	全體	quan2 ti3	all
+拳头	拳頭	quan2 tou5	fist
+权利	權利	quan2 li4	power
+劝	勸	quan4	to advise
+确实	確實	que4 shi2	indeed
+群众	群眾	qun2 zhong4	mass
+燃烧	燃燒	ran2 shao1	to ignite
+让步	讓步	rang4 bu4	to concede
+绕	繞	rao4	to wind
+热爱	熱愛	re4 ai4	to love ardently
+热烈	熱烈	re4 lie4	enthusiastic
+热门	熱門	re4 men2	popular
+热情	熱情	re4 qing2	cordial
+热心	熱心	re4 xin1	enthusiasm
+人权	人權	ren2 quan2	human rights
+人体	人體	ren2 ti3	human body
+人员	人員	ren2 yuan2	staff
+日后	日後	ri4 hou4	sometime
+荣幸	榮幸	rong2 xing4	honored (to have the privilege of ...)
+入学	入學	ru4 xue2	to enter a school or college
+软	軟	ruan3	soft
+赛跑	賽跑	sai4 pao3	race (running)
+丧失	喪失	sang4 shi1	to lose
+沙滩	沙灘	sha1 tan1	beach
+杀价	殺價	sha1 jia4	to beat down the price
+闪	閃	shan3	to dodge
+善于	善於	shan4 yu2	to be good at
+伤脑筋	傷腦筋	shang1 nao3 jin1	to be a real headache
+商标	商標	shang1 biao1	trademark
+商场	商場	shang1 chang3	shopping mall
+上级	上級	shang4 ji2	higher authorities
+上头	上頭	shang4 tou5	(of alcohol) to go to one's head
+少数	少數	shao3 shu4	small number
+舌头	舌頭	she2 tou5	tongue
+舍不得	捨不得	she3 bu4 de5	to hate to do sth
+舍得	捨得	she3 de5	to be willing to part with sth
+社会	社會	she4 hui4	society
+社团	社團	she4 tuan2	association
+设立	設立	she4 li4	to set up
+设置	設置	she4 zhi4	to set up
+摄影	攝影	she4 ying3	to take a photograph
+申请	申請	shen1 qing3	to apply for sth
+身分证	身分證	shen1 fen4 zheng4	identity card
+深浅	深淺	shen1 qian3	deep or shallow
+神话	神話	shen2 hua4	legend
+神经	神經	shen2 jing1	nerve
+神气	神氣	shen2 qi4	expression
+神圣	神聖	shen2 sheng4	divine
+审查	審查	shen3 cha2	to examine
+升级	升級	sheng1 ji2	to escalate (in intensity)
+升学	升學	sheng1 xue2	to enter the next grade school
+生长	生長	sheng1 zhang3	to grow
+绳	繩	sheng2	rope
+胜	勝	sheng4	victory
+胜利	勝利	sheng4 li4	victory
+失败	失敗	shi1 bai4	to be defeated
+失业	失業	shi1 ye4	unemployment
+诗	詩	shi1	poem
+诗人	詩人	shi1 ren2	bard
+师父	師父	shi1 fu5	used for 師傅|师傅 (in Taiwan)
+师傅	師傅	shi1 fu4	master
+师母	師母	shi1 mu3	term of respect for your teacher's wife
+时常	時常	shi2 chang2	often
+时机	時機	shi2 ji1	fortunate timing
+时期	時期	shi2 qi2	period
+时时	時時	shi2 shi2	often
+实用	實用	shi2 yong4	practical
+实施	實施	shi2 shi1	to implement
+实现	實現	shi2 xian4	to achieve
+实验	實驗	shi2 yan4	experiment
+始终	始終	shi3 zhong1	from beginning to end
+式样	式樣	shi4 yang4	style
+世纪	世紀	shi4 ji4	century
+市区	市區	shi4 qu1	urban district
+视野	視野	shi4 ye3	field of view
+适当	適當	shi4 dang4	suitable
+适合	適合	shi4 he2	to fit
+适用	適用	shi4 yong4	to be applicable
+事实上	事實上	shi4 shi2 shang4	in fact
+势力	勢力	shi4 li4	power
+试验	試驗	shi4 yan4	experiment
+收据	收據	shou1 ju4	receipt
+手电筒	手電筒	shou3 dian4 tong3	flashlight
+手术	手術	shou3 shu4	(surgical) operation
+寿命	壽命	shou4 ming4	life span
+书房	書房	shu1 fang2	study (room)
+书籍	書籍	shu1 ji2	books
+输出	輸出	shu1 chu1	to export
+输入	輸入	shu1 ru4	to import
+熟练	熟練	shu2 lian4	practiced
+属于	屬於	shu3 yu2	to be classified as
+数量	數量	shu4 liang4	amount
+数目	數目	shu4 mu4	amount
+树林	樹林	shu4 lin2	woods
+率领	率領	shuai4 ling3	to lead
+双胞胎	雙胞胎	shuang1 bao1 tai1	twin
+双方	雙方	shuang1 fang1	bilateral
+水灾	水災	shui3 zai1	flood
+税	稅	shui4	taxes
+说服	說服	shui4 fu2	to persuade
+顺手	順手	shun4 shou3	easily
+顺序	順序	shun4 xu4	sequence
+说不定	說不定	shuo1 bu5 ding4	can't say for sure
+硕士	碩士	shuo4 shi4	master's degree
+丝	絲	si1	silk
+四处	四處	si4 chu4	all over the place
+饲养	飼養	si4 yang3	to raise
+俗话	俗話	su2 hua4	common saying
+俗话说	俗話說	su2 hua4 shuo1	as the proverb says
+算帐	算帳	suan4 zhang4	to reckon (accounting)
+随手	隨手	sui2 shou3	conveniently
+随意	隨意	sui2 yi4	as one wishes
+随着	隨著	sui2 zhe5	along with
+岁数	歲數	sui4 shu5	age (number of years old)
+孙女	孫女	sun1 nü3	son's daughter
+孙子	孫子	sun1 zi5	Sun Tzu, also known as Sun Wu 孫武|孙武[Sun1 Wu3] (c. 500 BC, dates of birth and death uncertain), general, strategist and philosopher of the Spring and Autumn Period (700-475 BC), believed to be the author of the “Art of War” 孫子兵法|孙子兵法[Sun1 zi3 Bing1 fa3], one of the Seven Military Classics of ancient China 武經七書|武经七书[Wu3 jing1 Qi1 shu1]
+损失	損失	sun3 shi1	loss
+缩	縮	suo1	to withdraw
+缩短	縮短	suo1 duan3	to curtail
+缩水	縮水	suo1 shui3	to shrink (in the wash)
+锁	鎖	suo3	to lock up
+抬头	抬頭	tai2 tou2	to raise one's head
+摊子	攤子	tan1 zi5	booth
+弹	彈	tan2	crossball
+谈判	談判	tan2 pan4	to negotiate
+探亲	探親	tan4 qin1	to go home to visit one's family
+探讨	探討	tan4 tao3	to investigate
+烫	燙	tang4	to scald
+淘气	淘氣	tao2 qi4	naughty
+特点	特點	te4 dian3	characteristic (feature)
+体温	體溫	ti3 wen1	(body) temperature
+体验	體驗	ti3 yan4	to experience for oneself
+挑选	挑選	tiao1 xuan3	to choose
+条约	條約	tiao2 yue1	treaty
+调整	調整	tiao2 zheng3	to adjust
+跳远	跳遠	tiao4 yuan3	long jump (athletics)
+贴心	貼心	tie1 xin1	intimate
+通讯	通訊	tong1 xun4	communications
+铜	銅	tong2	copper (chemistry)
+统计	統計	tong3 ji4	statistics
+统一	統一	tong3 yi1	to unify
+统治	統治	tong3 zhi4	to rule (a country)
+头脑	頭腦	tou2 nao3	brains
+透过	透過	tou4 guo4	to pass through
+秃	禿	tu1	bald
+途径	途徑	tu2 jing4	way
+图书	圖書	tu2 shu1	books (in a library or bookstore)
+图章	圖章	tu2 zhang1	stamp
+团结	團結	tuan2 jie2	to unite
+推动	推動	tui1 dong4	to push (for acceptance of a plan)
+推广	推廣	tui1 guang3	to extend
+托儿所	托兒所	tuo1 er2 suo3	nursery
+脱离	脫離	tuo1 li2	to separate oneself from
+妥当	妥當	tuo3 dang5	appropriate
+妥协	妥協	tuo3 xie2	to compromise
+外观	外觀	wai4 guan1	exterior appearance
+外汇	外匯	wai4 hui4	foreign (currency) exchange
+外头	外頭	wai4 tou5	outside
+弯	彎	wan1	to bend
+弯腰	彎腰	wan1 yao1	to stoop
+完毕	完畢	wan2 bi4	to finish
+晚辈	晚輩	wan3 bei4	the younger generation
+威胁	威脅	wei1 xie2	to threaten
+违反	違反	wei2 fan3	to violate (a law)
+维护	維護	wei2 hu4	to defend
+维他命	維他命	wei2 ta1 ming4	vitamin (loanword)
+危机	危機	wei2 ji1	crisis
+为难	為難	wei2 nan2	to feel embarrassed or awkward
+委托	委託	wei3 tuo1	to entrust
+委员	委員	wei3 yuan2	committee member
+位于	位於	wei4 yu2	to be located at
+为何	為何	wei4 he2	why
+卫生	衛生	wei4 sheng1	health
+卫生纸	衛生紙	wei4 sheng1 zhi3	toilet paper
+卫星	衛星	wei4 xing1	satellite
+慰问	慰問	wei4 wen4	to express sympathy, greetings, consolation etc
+温和	溫和	wen1 he2	mild
+文凭	文憑	wen2 ping2	diploma
+文艺	文藝	wen2 yi4	literature and art
+卧房	臥房	wo4 fang2	bedroom
+无可奈何	無可奈何	wu2 ken3 ai4 he2	have no way out
+无论	無論	wu2 lun4	no matter what or how
+无情	無情	wu2 qing2	pitiless
+无数	無數	wu2 shu4	countless
+无限	無限	wu2 xian4	unlimited
+无意	無意	wu2 yi4	inadvertent
+武术	武術	wu3 shu4	military skill or technique (in former times)
+舞厅	舞廳	wu3 ting1	dance hall
+物质	物質	wu4 zhi2	matter
+误点	誤點	wu4 dian3	not on time
+雾	霧	wu4	fog
+西装	西裝	xi1 zhuang1	suit
+媳妇	媳婦	xi2 fu4	daughter-in-law
+喜剧	喜劇	xi3 ju4	comedy
+细胞	細胞	xi4 bao1	cell (biology)
+细节	細節	xi4 jie2	details
+细菌	細菌	xi4 jun4	bacterium
+细小	細小	xi4 xiao3	tiny
+虾	蝦	xia1	shrimp
+虾米	蝦米	xia1 mi5	small shrimp
+先进	先進	xian1 jin4	advanced (technology)
+鲜花	鮮花	xian1 hua1	flower
+鲜奶	鮮奶	xian1 nai3	fresh milk
+鲜血	鮮血	xian1 xie3	blood
+闲	閒	xian2	unoccupied
+显得	顯得	xian3 de5	to seem
+显然	顯然	xian3 ran2	clear
+显示	顯示	xian3 shi4	to show
+显著	顯著	xian3 zhu4	outstanding
+现场	現場	xian4 chang3	the scene (of a crime, accident etc)
+现成	現成	xian4 cheng2	ready-made
+现金	現金	xian4 jin1	cash
+羡慕	羨慕	xian4 mu4	to envy
+相处	相處	xiang1 chu3	to be in contact (with sb)
+相亲相爱	相親相愛	xiang1 qin1 xian1 gai4	to be kind and love one another (idiom); bound by deep emotions
+香肠	香腸	xiang1 chang2	sausage
+乡村	鄉村	xiang1 cun1	rustic
+响应	響應	xiang3 ying4	to respond to
+相亲	相親	xiang4 qin1	blind date
+向来	向來	xiang4 lai2	always (previously)
+项目	項目	xiang4 mu4	item
+消费	消費	xiao1 fei4	to consume
+消极	消極	xiao1 ji2	negative
+消灭	消滅	xiao1 mie4	to put an end to
+销路	銷路	xiao1 lu4	sale
+销售	銷售	xiao1 shou4	to sell
+小费	小費	xiao3 fei4	tip
+小麦	小麥	xiao3 mai4	wheat
+小气	小氣	xiao3 qi4	stingy
+晓得	曉得	xiao3 de5	to know
+校车	校車	xiao4 che1	school bus
+心灵	心靈	xin1 ling2	bright
+心声	心聲	xin1 sheng1	thoughts
+心脏	心臟	xin1 zang4	heart
+新兴	新興	xin1 xing1	new
+信号	信號	xin4 hao4	signal
+形状	形狀	xing2 zhuang4	form
+性质	性質	xing4 zhi2	nature
+雄伟	雄偉	xiong2 wei3	grand
+休闲	休閒	xiu1 xian2	leisure
+须知	須知	xu1 zhi1	key information
+许愿	許願	xu3 yuan4	to make a wish
+宣传	宣傳	xuan1 chuan2	to disseminate
+悬	懸	xuan2	to hang or suspend
+选手	選手	xuan3 shou3	athlete
+学历	學歷	xue2 li4	educational background
+学术	學術	xue2 shu4	learning
+学位	學位	xue2 wei4	academic degree
+学业	學業	xue2 ye4	studies
+学者	學者	xue2 zhe3	scholar
+削减	削減	xue4 jian3	to cut down
+循环	循環	xun2 huan2	to cycle
+压	壓	ya1	to press
+压力	壓力	ya1 li4	pressure
+压迫	壓迫	ya1 po4	to oppress
+严格	嚴格	yan2 ge2	strict
+严肃	嚴肅	yan2 su4	solemn
+盐巴	鹽巴	yan2 ba1	table salt
+延长	延長	yan2 chang2	to prolong
+掩盖	掩蓋	yan3 gai4	to conceal
+宴会	宴會	yan4 hui4	banquet
+厌恶	厭惡	yan4 wu4	to loathe
+痒	癢	yang3	to itch
+氧气	氧氣	yang3 qi4	oxygen
+样品	樣品	yang4 pin3	sample
+摇	搖	yao2	to shake
+摇摆	搖擺	yao2 bai3	to sway
+摇头	搖頭	yao2 tou2	to shake one's head
+药方	藥方	yao4 fang1	prescription
+药水	藥水	yao4 shui3	Yaksu in North Korea, near the border with Liaoning and Jiling province
+药物	藥物	yao4 wu4	medicaments
+野兽	野獸	ye3 shou4	beast
+业务	業務	ye4 wu4	business
+业余	業餘	ye4 yu2	in one's spare time
+叶子	葉子	ye4 zi5	foliage
+依据	依據	yi1 ju4	according to
+医师	醫師	yi1 shi1	doctor
+医学	醫學	yi1 xue2	medicine
+一带	一帶	yi1 dai4	region
+移动	移動	yi2 dong4	to move
+疑问	疑問	yi2 wen4	question
+仪器	儀器	yi2 qi4	instrument
+仪式	儀式	yi2 shi4	ceremony
+一口气	一口氣	yi1 kou3 qi4	one breath
+一齐	一齊	yi1 qi2	at the same time
+意识	意識	yi4 shi4	consciousness
+意愿	意願	yi4 yuan4	aspiration
+亿	億	yi4	100 million
+义务	義務	yi4 wu4	duty
+议会	議會	yi4 hui4	parliament
+引发	引發	yin3 fa1	to lead to
+饮食	飲食	yin3 shi2	food and drink
+应当	應當	ying1 dang1	should
+婴儿	嬰兒	ying1 er2	infant
+赢得	贏得	ying2 de2	to win
+营业	營業	ying2 ye4	to do business
+应付	應付	ying4 fu4	to deal with
+应邀	應邀	ying4 yao1	at sb's invitation
+应用	應用	ying4 yong4	to use
+拥抱	擁抱	yong3 bao4	to embrace
+拥护	擁護	yong3 hu4	to endorse
+拥挤	擁擠	yong3 ji3	crowded
+勇气	勇氣	yong3 qi4	courage
+用不着	用不著	yong4 bu4 zhao2	not need
+用处	用處	yong4 chu5	usefulness
+用得着	用得著	yong4 de5 zhao2	to be able to use
+忧郁	憂鬱	you1 yu4	sullen
+优惠	優惠	you1 hui4	preferential
+优良	優良	you1 liang2	fine
+优美	優美	you1 mei3	graceful
+优越	優越	you1 yue4	superior
+油腻	油膩	you2 ni4	grease
+邮差	郵差	you2 chai1	(old) postman
+邮件	郵件	you2 jian4	mail
+游戏	遊戲	you2 xi4	game
+游行	遊行	you2 xing2	march
+犹豫	猶豫	you2 yu4	to hesitate
+有关	有關	you3 guan1	to have sth to do with
+娱乐	娛樂	yu2 le4	to entertain
+语调	語調	yu3 diao4	intonation
+语气	語氣	yu3 qi4	tone
+语音	語音	yu3 yin1	speech sounds
+与其	與其	yu3 qi2	rather than...
+遇见	遇見	yu4 jian4	to meet
+预报	預報	yu4 bao4	forecast
+预定	預定	yu4 ding4	to schedule in advance
+预订	預訂	yu4 ding4	to place an order
+预计	預計	yu4 ji4	to forecast
+预算	預算	yu4 suan4	budget
+预先	預先	yu4 xian1	beforehand
+原则	原則	yuan2 ze2	principle
+原则上	原則上	yuan2 ze2 shang4	in principle
+原子笔	原子筆	yuan2 zi3 bi3	ballpoint pen
+圆满	圓滿	yuan2 man3	satisfactory
+圆形	圓形	yuan2 xing2	round
+缘故	緣故	yuan2 gu4	reason
+远大	遠大	yuan3 da4	far-reaching
+晕	暈	yun1	confused
+允许	允許	yun3 xu3	to permit
+运输	運輸	yun4 shu1	transport
+运送	運送	yun4 song4	to transport
+运用	運用	yun4 yong4	to use
+运转	運轉	yun4 zhuan3	to work
+灾害	災害	zai1 hai4	calamity
+灾难	災難	zai1 nan4	disaster
+再说	再說	zai4 shuo1	to say again
+咱们	咱們	zan2 men5	we or us (including both the speaker and the person(s) spoken to)
+赞成	贊成	zan4 cheng2	to approve
+赞同	贊同	zan4 tong2	to approve of
+赞美	讚美	zan4 mei3	to admire
+葬礼	葬禮	zang4 li3	burial
+早点	早點	zao3 dian3	breakfast
+增长	增長	zeng1 zhang3	to grow
+赠品	贈品	zeng4 pin3	gift
+赠送	贈送	zeng4 song4	to present as a gift
+展开	展開	zhan3 kai1	to unfold
+展览	展覽	zhan3 lan3	to put on display
+战场	戰場	zhan4 chang3	battlefield
+长辈	長輩	zhang3 bei4	one's elders
+涨	漲	zhang3	to rise (of prices, rivers)
+涨价	漲價	zhang3 jia4	to appreciate (in value)
+掌声	掌聲	zhang3 sheng1	applause
+帐单	帳單	zhang4 dan1	bill
+召开	召開	zhao4 kai1	to convene (a conference or meeting)
+针对	針對	zhen1 dui4	to target
+侦探	偵探	zhen1 tan4	detective
+枕头	枕頭	zhen3 tou5	pillow
+阵	陣	zhen4	disposition of troops
+阵子	陣子	zhen4 zi5	period of time
+震动	震動	zhen4 dong4	to shake
+争论	爭論	zheng1 lun4	to argue
+争取	爭取	zheng1 qu3	to fight for
+睁	睜	zheng1	to open (one's eyes)
+征求	徵求	zheng1 qiu2	to solicit
+整洁	整潔	zheng3 jie2	neatly
+整数	整數	zheng3 shu4	whole number
+正规	正規	zheng4 gui1	regular
+正经	正經	zheng4 jing5	decent
+政党	政黨	zheng4 dang3	political party
+证件	證件	zheng4 jian4	certificate
+证据	證據	zheng4 ju4	evidence
+证实	證實	zheng4 shi2	to confirm (sth to be true)
+症状	症狀	zheng4 zhuang4	symptom (of an illness)
+之类	之類	zhi1 lei4	and so on
+直线	直線	zhi2 xian4	straight line
+掷	擲	zhi2	to toss
+职位	職位	zhi2 wei4	post
+执行	執行	zhi2 xing2	to implement
+指导	指導	zhi3 dao3	to guide
+指责	指責	zhi3 ze2	to criticize
+纸张	紙張	zhi3 zhang1	paper
+志气	志氣	zhi4 qi4	ambition
+志愿	志願	zhi4 yuan4	aspiration
+制造	製造	zhi4 zao4	to manufacture
+制作	製作	zhi4 zuo4	to make
+中级	中級	zhong1 ji2	middle level (in a hierarchy)
+中药	中藥	zhong1 yao4	(traditional) Chinese medicine
+肿	腫	zhong3	to swell
+种类	種類	zhong3 lei4	kind
+种子	種子	zhong3 zi3	seed
+种族	種族	zhong3 zu2	race
+重伤	重傷	zhong4 shang1	seriously hurt
+逐渐	逐漸	zhu2 jian4	gradually
+主办	主辦	zhu3 ban4	to organize
+主观	主觀	zhu3 guan1	subjective
+主张	主張	zhu3 zhang1	to advocate
+祝贺	祝賀	zhu4 he4	to congratulate
+注册	註冊	zhu4 ce4	to register
+专家	專家	zhuan1 jia1	expert
+专利	專利	zhuan1 li4	patent
+专门	專門	zhuan1 men2	specialist
+专人	專人	zhuan1 ren2	specialist
+转变	轉變	zhuan3 bian4	to change
+转播	轉播	zhuan3 bo4	relay
+转达	轉達	zhuan3 da2	to pass on
+转告	轉告	zhuan3 gao4	to pass on
+转机	轉機	zhuan3 ji1	(to take) a turn for the better
+转身	轉身	zhuan3 shen1	(of a person) to turn round
+转向	轉向	zhuan3 xiang4	to change direction
+赚	賺	zhuan4	to earn
+装饰	裝飾	zhuang1 shi4	to decorate
+壮	壯	zhuang4	Zhuang ethnic group of Guangxi, the PRC's second most numerous ethnic group
+状况	狀況	zhuang4 kuang4	condition
+准考证	准考證	zhun3 kao3 zheng4	(exam) admission ticket
+准确	準確	zhun3 que4	accurate
+资本	資本	zi1 ben3	capital (economics)
+资格	資格	zi1 ge2	qualifications
+资金	資金	zi1 jin1	funds
+资讯	資訊	zi1 xun4	information
+自来水	自來水	zi4 lai2 shui3	running water
+自愿	自願	zi4 yuan4	voluntary
+总共	總共	zong3 gong4	altogether
+总理	總理	zong3 li3	premier
+综合	綜合	zong4 he2	comprehensive
+组织	組織	zu3 zhi1	to organize
+阻碍	阻礙	zu3 ai4	to obstruct
+祖国	祖國	zu3 guo2	motherland
+钻	鑽	zuan1	to drill
+钻石	鑽石	zuan4 shi2	diamond
+作为	作為	zuo4 wei2	one's conduct

--- a/cordova-build-override/www/assets/lists/tocfl7.list
+++ b/cordova-build-override/www/assets/lists/tocfl7.list
@@ -1,0 +1,1599 @@
+爱戴	愛戴	ai4 dai4	to love and respect
+爱国	愛國	ai4 guo2	to love one's country
+爱滋病	愛滋病	ai4 zi1 bing4	variant of 艾滋病[ai4 zi1 bing4]
+安顿	安頓	an1 dun4	to find a place for
+安抚	安撫	an1 fu3	to placate
+安宁	安寧	an1 ning2	peaceful
+安详	安詳	an1 xiang2	serene
+昂贵	昂貴	ang2 gui4	expensive
+奥妙	奧妙	ao4 miao4	marvelous
+懊恼	懊惱	ao4 nao3	annoyed
+白皮书	白皮書	bai2 pi2 shu1	white paper (e.g. containing proposals for new legislation)
+拜会	拜會	bai4 hui4	pay an official call
+颁发	頒發	ban1 fa1	to issue
+颁奖	頒獎	ban1 jiang3	to confer an award
+办案	辦案	ban4 an4	to handle a case
+半岛	半島	ban4 dao3	peninsula
+半导体	半導體	ban4 dao3 ti3	semiconductor
+绑	綁	bang3	to tie
+包围	包圍	bao1 wei2	to surround
+宝石	寶石	bao3 shi2	precious stone
+饱和	飽和	bao3 he2	saturation
+饱满	飽滿	bao3 man3	full
+保龄球	保齡球	bao3 ling2 qiu2	ten-pin bowling (loanword)
+报案	報案	bao4 an4	to report a case to the authorities
+报表	報表	bao4 biao3	forms for reporting statistics
+报酬	報酬	bao4 chou2	reward
+报复	報復	bao4 fu4	to make reprisals
+报关	報關	bao4 guan1	to declare at customs
+报价	報價	bao4 jia4	to quote a price
+报刊	報刊	bao4 kan1	newspapers and periodicals
+报应	報應	bao4 ying4	retribution
+报章	報章	bao4 zhang1	newspapers
+爆发	爆發	bao4 fa1	to break out
+抱负	抱負	bao4 fu4	aspiration
+悲观	悲觀	bei1 guan1	pessimistic
+贝壳	貝殼	bei4 ke2	shell
+倍数	倍數	bei4 shu4	multiple
+背诵	背誦	bei4 song4	to recite
+奔腾	奔騰	ben1 teng2	Pentium (microprocessor by Intel)
+本质	本質	ben3 zhi2	essence
+崩溃	崩潰	beng1 kui4	to collapse
+编辑	編輯	bian1 ji2	to edit
+编写	編寫	bian1 xie3	to compile
+编织	編織	bian1 zhi1	to weave
+编制	編制, 編製	bian1 zhi4	to establish (a unit or department)
+边界	邊界	bian1 jie4	boundary
+边缘	邊緣	bian1 yuan2	edge
+贬	貶	bian3	to diminish
+贬值	貶值	bian3 zhi2	to become devaluated
+匾额	匾額	bian3 e2	a horizontal inscribed board
+辨认	辨認	bian4 ren4	to recognize
+辨识	辨識	bian4 shi4	identification
+辩	辯	bian4	to dispute
+辩护	辯護	bian4 hu4	to speak in defense of
+辩论	辯論	bian4 lun4	debate
+变革	變革	bian4 ge2	to transform
+变迁	變遷	bian4 qian1	changes
+变通	變通	bian4 tong1	pragmatic
+变形	變形	bian4 xing2	deformation
+标签	標籤	biao1 qian1	label
+标语	標語	biao1 yu3	written slogan
+笔录	筆錄	bi3 lu4	to put down in writing
+笔友	筆友	bi3 you3	pen pal
+比拟	比擬	bin3	to compare
+必备	必備	bi4 bei4	essential
+闭幕	閉幕	bi4 mu4	the curtain falls
+闭塞	閉塞	bi4 se4	to stop up
+避难	避難	bin4 an4	refuge
+毕生	畢生	bi4 sheng1	all one's life
+币值	幣值	bi4 zhi2	value of a currency
+别墅	別墅	bie2 shu4	villa
+宾馆	賓館	bin1 guan3	guesthouse
+并列	並列	bing4 lie4	to stand side by side
+并重	並重	bing4 zhong4	to lay equal stress on
+并发	併發	bing4 fa1	to be complicated by
+剥	剝	bo1	to peel
+剥削	剝削	bo1 xue4	to exploit
+搏斗	搏鬥	bo2 dou4	to wrestle
+补给	補給	bu3 ji3	supply
+补救	補救	bu3 jiu4	to remedy
+补习班	補習班	bu3 xi2 ban1	cram class
+哺乳动物	哺乳動物	bu3 ru3 dong4 wu4	mammal
+不动产	不動產	bu4 dong4 chan3	real estate
+不时	不時	bu4 shi2	from time to time
+不知不觉	不知不覺	bu4 zhi1 bu4 jue2	unconsciously
+步调	步調	bu4 diao4	gait
+步骤	步驟	bu4 zou4	procedure
+猜测	猜測	cai1 ce4	to guess
+裁缝	裁縫	cai2 feng2	tailor
+裁减	裁減	cai2 jian3	to reduce
+财团	財團	cai2 tuan2	financial group
+财政	財政	cai2 zheng4	finances (public)
+采访	採訪	cai3 fang3	to interview
+采光	採光	cai3 guang1	lighting
+采纳	採納	cai3 na4	to accept
+采取	採取	cai3 qu3	to adopt or carry out (measures, policies, course of action)
+彩绘	彩繪	cai3 hui4	painted
+参谋	參謀	can1 mou2	staff officer
+残暴	殘暴	can2 bao4	brutal
+残酷	殘酷	can2 ku4	cruel
+残杀	殘殺	can2 sha1	to massacre
+惨重	慘重	can3 zhong4	disastrous
+灿烂	燦爛	can4 lan4	to glitter
+苍白	蒼白	cang1 bai2	pale
+苍蝇	蒼蠅	cang1 ying5	housefly
+操纵	操縱	cao1 zong4	to operate
+草丛	草叢	cao3 cong2	underbrush
+草药	草藥	cao3 yao4	herbal medicine
+策画	策畫	ce4 hua4	variant of 策劃|策划[ce4 hua4]
+差额	差額	cha1 e2	balance (financial)
+察觉	察覺	cha2 jue2	to sense
+蝉	蟬	chan2	cicada
+馋	饞	chan2	gluttonous
+长远	長遠	chang2 yuan3	long-term
+场次	場次	chang3 ci4	the number of showings of a movie, play etc
+场面	場面	chang3 mian4	scene
+倡导	倡導	chang4 dao3	to advocate
+畅销	暢銷	chang4 xiao1	to sell well
+产物	產物	chan3 wu4	product
+产值	產值	chan3 zhi2	value of output
+超脱	超脫	chao1 tuo1	to stand aloof
+抄袭	抄襲	chao1 xi2	to plagiarize
+车辆	車輛	che1 liang4	vehicle
+车厢	車廂	che1 xiang1	carriage
+撤销	撤銷	che4 xiao1	to repeal
+尘土	塵土	chen2 tu3	dust
+承担	承擔	cheng2 dan1	to undertake
+承诺	承諾	cheng2 nuo4	to promise
+成败	成敗	cheng2 bai4	success or failure
+成见	成見	cheng2 jian4	preconceived idea
+成员	成員	cheng2 yuan2	member
+称号	稱號	cheng1 hao4	name
+称呼	稱呼	cheng1 hu1	to call
+撑腰	撐腰	cheng1 yao1	to support
+呈献	呈獻	cheng2 xian4	to present respectfully
+诚心	誠心	cheng2 xin1	sincerity
+诚心诚意	誠心誠意	cheng2 xin1 cheng2 yi4	earnestly and sincerely (idiom); with all sincerity
+诚挚	誠摯	cheng2 zhi4	sincere
+吃惊	吃驚	chi1 jing1	to be startled
+持续	持續	chi2 xu4	to continue
+迟钝	遲鈍	chi2 dun4	slow in one's reactions
+冲淡	沖淡	chong1 dan4	to dilute
+冲天	沖天	chong1 tian1	to soar
+冲动	衝動	chong1 dong4	to have an urge
+冲击	衝擊	chong1 ji2	to attack
+冲突	衝突	chong1 tu2	conflict
+重叠	重疊	chong2 die2	to overlap
+宠爱	寵愛	o5 gai4	to dote on sb
+宠物	寵物	chong3 wu4	house pet
+抽样	抽樣	chou1 yang4	sample
+出错	出錯	chu1 cuo4	to make a mistake
+出发点	出發點	chu1 fa1 dian3	starting point
+出马	出馬	chu1 ma3	to set out (on a campaign)
+出卖	出賣	chu1 mai4	to offer for sale
+出头	出頭	chu1 tou2	to get out of a predicament
+储备	儲備	chu2 bei4	reserves
+锄头	鋤頭	chu2 tou5	hoe
+处方	處方	chu3 fang1	medical prescription
+处分	處分	chu3 fen4	to discipline sb
+处境	處境	chu3 jing4	situation (of a person)
+处事	處事	chu3 shi4	to handle affairs
+处于	處於	chu3 yu2	to be in (some state, position, or condition)
+处女	處女	chun3	virgin
+传递	傳遞	chuan2 di4	to transmit
+传奇	傳奇	chuan2 qi2	legendary
+传神	傳神	chuan2 shen2	vivid
+传授	傳授	chuan2 shou4	to impart
+船只	船隻	chuan2 zhi1	ship
+创伤	創傷	chuang1 shang1	wound
+创办	創辦	chuang4 ban4	to establish
+创立	創立	chuang4 li4	to establish
+创新	創新	chuang4 xin1	innovation
+创业	創業	chuang4 ye4	to begin an undertaking
+辞典	辭典	ci2 dian3	dictionary (of Chinese compound words)
+辞行	辭行	ci2 xing2	to say goodbye
+刺杀	刺殺	ci4 sha1	to assassinate
+从容	從容	cong1 rong2	to go easy
+从而	從而	cong2 er2	thus
+凑巧	湊巧	cou4 qiao3	fortuitously
+粗鲁	粗魯	cu1 lu3	coarse
+促销	促銷	cu4 xiao1	to promote sales
+簇拥	簇擁	cu4 yong3	to crowd around
+摧残	摧殘	cui1 can2	to ravage
+摧毁	摧毀	cui1 hui3	to destroy
+存货	存貨	cun2 huo4	stock
+答复	答覆	da2 fu4	to answer
+打斗	打鬥	da3 dou4	to fight
+打赌	打賭	da3 du3	to bet
+打发	打發	da3 fa5	to dispatch sb to do sth
+打击	打擊	da3 ji2	to hit
+打猎	打獵	da3 lie4	to go hunting
+大队	大隊	da4 dui4	group
+大选	大選	da4 xuan3	general election
+代课	代課	dai4 ke4	to teach as substitute for absent teacher
+担当	擔當	dan1 dang1	to take upon oneself
+担负	擔負	dan1 fu4	to shoulder
+单独	單獨	dan1 du2	alone
+单价	單價	dan1 jia4	unit price
+单据	單據	dan1 ju4	receipts
+单亲	單親	dan1 qin1	single parent
+单行道	單行道	dan1 xing2 dao4	one-way street
+胆固醇	膽固醇	dan3 gu4 chun2	cholesterol
+导师	導師	dao3 shi1	tutor
+导致	導致	dao3 zhi4	to lead to
+岛屿	島嶼	dao3 yu3	island
+道别	道別	dao4 bie2	leave taking
+道义	道義	dao4 yi4	morality
+到头来	到頭來	dao4 tou2 lai2	in the end
+倒数	倒數	dao4 shu3	to count backwards (from 10 down to 0)
+当兵	當兵	dang1 bing1	to serve in the army
+当代	當代	dang1 dai4	the present age
+当局	當局	dang1 ju2	authorities
+当前	當前	dang1 qian2	current
+当心	當心	dang1 xin1	to take care
+党派	黨派	dang3 pai4	political party
+党员	黨員	dang3 yuan2	political party member
+登场	登場	deng1 chang3	to go on stage
+登陆	登陸	deng1 lu4	to land
+灯火	燈火	deng1 huo3	lights
+灯笼	燈籠	deng1 long5	lantern
+等价	等價	deng3 jia4	equal
+地势	地勢	di4 shi4	terrain
+地狱	地獄	di4 yu4	hell
+地质	地質	di4 zhi2	geology
+缔结	締結	di4 jie2	to conclude (an agreement)
+缔造	締造	di4 zao4	to found
+颠覆	顛覆	dian1 fu4	to topple (i.e. knock over)
+点子	點子	dian3 zi5	spot
+惦记	惦記	dian4 ji4	to think of
+电工	電工	dian4 gong1	electrician
+电力	電力	dian4 li4	electrical power
+电流	電流	dian4 liu2	electric current
+电器	電器	dian4 qi4	(electrical) appliance
+电视剧	電視劇	dian4 shi4 ju4	TV play
+电压	電壓	dian4 ya1	voltage
+调度	調度	diao4 du4	to dispatch (vehicles, staff etc)
+吊桥	吊橋	diao4 qiao2	drawbridge
+钓鱼	釣魚	diao4 yu2	to fish (with line and hook)
+定额	定額	di5 ge2	fixed amount
+定义	定義	ding4 yi4	definition
+钉	釘	ding4	nail
+订购	訂購	ding4 gou4	to place an order
+丢弃	丟棄	diu1 qi4	to discard
+冻结	凍結	dong4 jie2	to freeze (water etc)
+动产	動產	dong4 chan3	movable property
+动机	動機	dong4 ji1	motor
+动静	動靜	dong4 jing4	(detectable) movement
+动力	動力	dong4 li4	motive power
+动乱	動亂	dong4 luan4	turmoil
+动脉	動脈	dong4 mai4	artery
+动态	動態	dong4 tai4	movement
+动向	動向	dong4 xiang4	trend
+动员	動員	dong4 yuan2	to mobilize
+斗志	鬥志	dou4 zhi4	will to fight
+独创	獨創	du2 chuang4	to come up with (an innovation)
+独到	獨到	du2 dao4	original
+读物	讀物	du2 wu4	reading material
+赌博	賭博	du3 bo2	to gamble
+赌场	賭場	du3 chang3	casino
+短暂	短暫	duan3 zhan4	of short duration
+断绝	斷絕	duan4 jue2	to sever
+堆积	堆積	dui1 ji1	to pile up
+队伍	隊伍	dui4 wu3	ranks
+兑现	兌現	dui4 xian4	(of a check etc) to cash
+对比	對比	dui4 bi3	to contrast
+对照	對照	dui4 zhao4	to contrast
+对峙	對峙	dui4 zhi4	to stand opposite
+顿时	頓時	dun4 shi2	immediately
+多亏	多虧	duo1 kui1	thanks to
+多媒体	多媒體	duo1 mei2 ti3	multimedia
+夺魁	奪魁	duo2 kui2	to seize
+堕胎	墮胎	duo4 tai1	to induce an abortion
+额外	額外	e2 wai4	extra
+恶化	惡化	e4 hua4	to worsen
+恶性	惡性	e4 xing4	malignant
+恶意	惡意	e4 yi4	malice
+恩爱	恩愛	en1 ai4	loving affection (in a couple)
+儿女	兒女	er2 nü3	children
+发电	發電	fa1 dian4	to generate electricity
+发疯	發瘋	fa1 feng1	to go mad
+发掘	發掘	fa1 jue2	to excavate
+发誓	發誓	fa1 shi4	to vow
+发炎	發炎	fa1 yan2	to become inflamed
+发育	發育	fa1 yu4	to develop
+发作	發作	fa1 zuo4	to flare up
+法则	法則	fa3 ze2	law
+翻脸	翻臉	fan1 lian3	to fall out with sb
+繁体	繁體	fan2 ti3	traditional form of Chinese, as opposed to simplified form 簡體|简体[jian3 ti3]
+藩篱	藩籬	fan2 li2	hedge
+反击	反擊	fan3 ji2	to strike back
+犯规	犯規	fan4 gui1	to break the rules
+贩毒	販毒	fan4 du2	to traffic narcotics
+贩卖	販賣	fan4 mai4	to sell
+方向盘	方向盤	fang1 xiang4 pan2	steering wheel
+方针	方針	fang1 zhen1	policy
+妨碍	妨礙	fan2 gai4	to hinder
+防备	防備	fang2 bei4	to guard against
+防范	防範	fang2 fan4	to be on guard
+防卫	防衛	fang2 wei4	to defend
+防御	防禦	fang2 yu4	defense
+纺织	紡織	fang3 zhi1	spinning and weaving
+放荡	放蕩	fang4 dang4	unconventional
+放宽	放寬	fang4 kuan1	to relax restrictions
+放松	放鬆	fang4 song1	to loosen
+飞弹	飛彈	fei1 dan4	missile
+飞快	飛快	fei1 kuai4	very fast
+飞翔	飛翔	fei1 xiang2	to circle in the air
+飞行	飛行	fei1 xing2	(of planes etc) to fly
+废除	廢除	fei4 chu2	to abolish
+废弃	廢棄	fei4 qi4	to discard
+废墟	廢墟	fei4 xu1	ruins
+废止	廢止	fei4 zhi3	to repeal (a law)
+费力	費力	fei4 li4	to expend a great deal of effort
+沸腾	沸騰	fei4 teng2	(of a liquid) to boil
+分贝	分貝	fen1 bei4	decibel
+分担	分擔	fen1 dan1	to share (a burden, a cost, a responsibility)
+分发	分發	fen1 fa1	to distribute
+分级	分級	fen1 ji2	to rank
+分离	分離	fen1 li2	to separate
+坟墓	墳墓	fen2 mu4	grave
+粉红	粉紅	fen3 hong2	pink
+粪	糞	fen4	manure
+封闭	封閉	feng1 bi4	to seal
+封锁	封鎖	feng1 suo3	to blockade
+封条	封條	feng1 tiao2	seal
+风暴	風暴	feng1 bao4	storm
+风潮	風潮	feng1 chao2	tempest
+风光	風光	feng1 guang1	scene
+风化	風化	feng1 hua4	decency
+风力	風力	feng1 li4	wind force
+风尚	風尚	feng1 shang4	current custom
+风水	風水	feng1 shui5	feng shui
+风行	風行	feng1 xing2	to become fashionable
+锋面	鋒面	feng1 mian4	front (meteorology)
+丰盛	豐盛	feng1 sheng4	rich
+丰收	豐收	feng1 shou1	bumper harvest
+奉献	奉獻	feng4 xian4	to offer respectfully
+奉养	奉養	feng4 yang4	to look after (elderly parents)
+佛经	佛經	fo2 jing1	Buddhist texts
+否决	否決	fou3 jue2	to veto
+肤浅	膚淺	fu1 qian3	skin-deep
+俘虏	俘虜	fu2 lu3	captive
+浮动	浮動	fu2 dong4	to float and drift
+服从	服從	fu2 cong2	to obey (an order)
+服饰	服飾	fu2 shi4	apparel
+福气	福氣	fu2 qi4	good fortune
+辐射	輻射	fu2 she4	radiation
+斧头	斧頭	fu3 tou5	ax
+抚养	撫養	fu3 yang3	to foster
+抚育	撫育	fu3 yu4	to nurture
+腐烂	腐爛	fu3 lan4	to rot
+腐蚀	腐蝕	fu3 shi2	corrosion
+负面	負面	fu4 mian4	negative
+富贵	富貴	fu4 gui4	riches and honor
+妇人	婦人	fu4 ren2	married woman
+复苏	復甦	fu4 su1	to recover (health, economic)
+复原	復原	fu4 yuan2	to restore (sth) to (its) former condition
+赋予	賦予	fu4 yu3	to assign
+该死	該死	gai1 si3	Damn it!
+改编	改編	gai3 bian1	to adapt
+改观	改觀	gai3 guan1	change of appearance
+改选	改選	gai3 xuan3	reelection
+钙	鈣	gai4	calcium (chemistry)
+概况	概況	gai4 kuang4	general situation
+盖章	蓋章	gai4 zhang1	to affix a seal
+尴尬	尷尬	gan1 ga4	awkward
+干扰	干擾	gan1 rao3	to disturb
+干燥	乾燥	gan1 zao4	to dry (of weather, paint, cement etc)
+感触	感觸	gan3 chu4	one's thoughts and feelings
+赶忙	趕忙	gan3 mang2	to hurry
+纲领	綱領	gang1 ling3	program (i.e. plan of action)
+刚强	剛強	gang1 qiang2	firm
+钢铁	鋼鐵	gang1 tie3	steel
+岗位	崗位	gang3 wei4	a post
+高见	高見	gao1 jian4	wise opinion
+高压	高壓	gao1 ya1	high pressure
+告别	告別	gao4 bie2	to leave
+告状	告狀	gao4 zhuang4	to tell on sb
+歌颂	歌頌	ge1 song4	to sing the praises of
+鸽子	鴿子	ge1 zi5	pigeon
+隔阂	隔閡	ge2 he2	misunderstanding
+个数	個數	ge4 shu4	number of items or individuals
+个体	個體	ge4 ti3	individual
+给予	給予	gei3 yu3	to accord
+跟进	跟進	gen1 jin4	to follow
+更动	更動	geng1 dong4	to change
+工艺品	工藝品	gong1 yi4 pin3	handicraft article
+公费	公費	gong1 fei4	at public expense
+公会	公會	gong1 hui4	guild
+公认	公認	gong1 ren4	publicly known (to be)
+公务	公務	gong1 wu4	official business
+公务员	公務員	gong1 wu4 yuan2	functionary
+公债	公債	gong1 zhai4	government bond
+功劳	功勞	gong1 lao2	contribution
+攻读	攻讀	gong1 du2	to major (in a field)
+攻击	攻擊	gong1 ji2	to attack
+供给	供給	o1 ji3	to furnish
+宫殿	宮殿	gong1 dian4	palace
+恭维	恭維	gong1 wei2	to praise
+巩固	鞏固	gong3 gu4	to consolidate
+共产	共產	gong4 chan3	communist
+共和国	共和國	gong4 he2 guo2	republic
+共鸣	共鳴	gong4 ming2	resonance (physics)
+供养	供養	gong4 yang4	to supply
+勾结	勾結	gou1 jie2	to collude with
+构想	構想	gou4 xiang3	to conceive
+孤独	孤獨	gu1 du2	lonely
+孤儿	孤兒	gu1 er2	orphan
+辜负	辜負	gu1 fu4	to fail to live up (to expectations)
+估价	估價	gu1 jia4	to value
+古迹	古跡	gu3 ji1	places of historic interest
+鼓动	鼓動	gu3 dong4	to agitate
+固体	固體	gu4 ti3	solid
+固执	固執	gu4 zhi2	obstinate
+顾全	顧全	gu4 quan2	to give careful consideration to
+蜗牛	蝸牛	guan1	snail
+寡妇	寡婦	gua3 fu4	widow
+观测	觀測	guan1 ce4	to observe
+观感	觀感	guan1 gan3	one's impressions
+观看	觀看	guan1 kan4	to watch
+观摩	觀摩	guan1 mo2	to observe and emulate
+观望	觀望	guan1 wang4	to wait and see
+关税	關稅	guan1 shui4	customs duty
+关切	關切	guan1 qie4	to be deeply concerned
+关怀	關懷	guan1 huai2	care
+关头	關頭	guan1 tou2	juncture
+关照	關照	guan1 zhao4	to take care
+管线	管線	guan3 xian4	pipeline
+贯彻	貫徹	guan4 che4	to implement
+灌输	灌輸	guan4 shu1	to imbue with
+光顾	光顧	guang1 gu4	to visit (as a customer)
+光辉	光輝	guang1 hui1	radiance
+规范	規範	gui1 fan4	norm
+规格	規格	gui1 ge2	standard
+归	歸	gui1	to return
+归还	歸還	gui1 huan2	to return sth
+归纳	歸納	gui5 a4	to sum up
+轨道	軌道	gui3 dao4	orbit
+贵宾	貴賓	gui4 bin1	honored guest
+国产	國產	guo2 chan3	made in one's own country
+国防	國防	guo2 fang2	national defense
+国境	國境	guo2 jing4	national border
+国君	國君	guo2 jun1	monarch
+国民	國民	guo2 min2	nationals
+国营	國營	guo2 ying2	state-run (company etc)
+果断	果斷	guo3 duan4	firm
+果实	果實	guo3 shi2	fruit (produced by a plant)
+果树	果樹	guo3 shu4	fruit tree
+过关	過關	guo4 guan1	to cross a barrier
+过量	過量	guo4 liang4	excess
+过敏	過敏	guo4 min3	oversensitive
+过目	過目	guo4 mu4	to look over
+过人	過人	guo4 ren2	to surpass others
+过失	過失	guo4 shi1	error
+过瘾	過癮	guo4 yin3	to satisfy a craving
+过重	過重	guo4 zhong4	overweight (luggage)
+海啸	海嘯	hai3 xiao4	tsunami
+海运	海運	hai3 yun4	shipping by sea
+害虫	害蟲	hai4 chong2	injurious insect
+行号	行號	hang2 hao4	(registered) company
+号子	號子	hao4 zi5	work chant
+合并	合併	he2 bing4	to merge
+合约	合約	he2 yue1	treaty
+和谐	和諧	he2 xie2	harmonious
+核对	核對	he2 dui4	to check
+黑名单	黑名單	hei1 ming2 dan1	blacklist
+黑社会	黑社會	hei1 she4 hui4	criminal underworld
+轰动	轟動	hong1 dong4	to cause a sensation
+轰轰烈烈	轟轟烈烈	hong1 hong1 lie4 lie4	strong
+红利	紅利	hong2 li4	bonus
+红烧	紅燒	hong2 shao1	simmer-fried (dish)
+宏伟	宏偉	hong2 wei3	grand
+后辈	後輩	hou4 bei4	younger generation
+候选人	候選人	hou4 xuan3 ren2	candidate
+呼吁	呼籲	hu1 yu4	to call on (sb to do sth)
+壶	壺	hu2	pot
+胡乱	胡亂	hu2 luan4	careless
+户口	戶口	hu4 kou3	population (counted as number of households for census or taxation)
+互补	互補	hu4 bu3	complementary
+互动	互動	hu4 dong4	to interact
+花纹	花紋	hua1 wen2	decorative design
+花样	花樣	hua1 yang4	pattern
+划不来	划不來	hua2 bu4 lai2	not worth it
+划得来	划得來	hua2 de5 lai2	worth it
+华裔	華裔	hua2 yi4	ethnic Chinese
+话剧	話劇	hua4 ju4	stage play
+画面	畫面	hua4 mian4	scene
+画展	畫展	hua4 zhan3	art exhibition
+划时代	劃時代	hua4 shi2 dai4	epoch-marking
+怀疑	懷疑	huai2 yi2	to doubt (sth)
+欢送	歡送	huan1 song4	to see off
+换取	換取	huan4 qu3	to obtain (sth) in exchange
+慌张	慌張	huang1 zhang1	confused
+灰尘	灰塵	hui1 chen2	dust
+辉煌	輝煌	hui1 huang2	splendid
+回绝	回絕	hui2 jue2	to rebuff
+回	迴	hui2 xiang3	to curve
+毁损	毀損	hui3 sun3	impair, damage
+汇票	匯票	hui4 piao4	bill of exchange
+会见	會見	hui4 jian4	to meet with (sb who is paying a visit)
+会谈	會談	hui4 tan2	talks
+会意	會意	hui4 yi4	combined ideogram (one of the Six Methods 六書|六书[liu4 shu1] of forming Chinese characters)
+绘画	繪畫	hui4 hua4	drawing
+贿赂	賄賂	hui4 lu4	to bribe
+浑身	渾身	hun2 shen1	all over
+混浊	混濁	hun4 zhuo2	turbid
+火药	火藥	huo3 yao4	gunpowder
+货币	貨幣	huo4 bi4	currency
+货品	貨品	huo4 pin3	goods
+豁达	豁達	huo4 da2	optimistic
+基层	基層	ji1 ceng2	basic level
+机动	機動	ji1 dong4	locomotive
+机警	機警	ji1 jing3	perceptive
+机率	機率	ji1 lü4	probability
+机密	機密	ji1 mi4	secret
+机器人	機器人	ji1 qi4 ren2	mechanical person
+机制	機制	ji1 zhi4	mechanism
+肌肤	肌膚	ji1 fu1	skin
+饥饿	飢餓	ji1 e4	hunger
+即时	即時	ji2 shi2	immediate
+极端	極端	ji2 duan1	extreme
+极力	極力	ji2 li4	to make a supreme effort
+极为	極為	ji2 wei2	extremely
+集结	集結	ji2 jie2	to assemble
+集权	集權	ji2 quan2	centralized power (history), e.g. under an Emperor or party
+集体	集體	ji2 ti3	collective (decision)
+集团	集團	ji2 tuan2	group
+急诊	急診	ji2 zhen3	emergency call
+籍贯	籍貫	ji2 guan4	one's native place
+击落	擊落	ji2 luo4	to shoot down (a plane)
+继承	繼承	ji4 cheng2	to inherit
+季风	季風	ji4 feng1	monsoon
+剂量	劑量	ji4 liang4	dosage
+纪律	紀律	ji4 lü4	discipline
+技艺	技藝	ji4 yi4	skill
+家伙	傢伙	jia1 huo5	household dish, implement or furniture
+家家户户	家家戶戶	jia1 jia1 hu4 hu4	each and every family (idiom)
+家电	家電	jia1 dian4	household electric appliance
+家属	家屬	jia1 shu3	family member
+佳节	佳節	jia1 jie2	festive day
+加紧	加緊	jia1 jin3	to intensify
+枷锁	枷鎖	jia1 suo3	stocks and chain
+夹杂	夾雜	jia2 za2	to mix together (disparate substances)
+架构	架構	jia4 gou4	to construct
+监督	監督	jian1 du1	to control
+坚固	堅固	jian1 gu4	firm
+坚忍	堅忍	jian1 ren3	persevering
+坚信	堅信	jian1 xin4	to believe firmly
+坚硬	堅硬	jian1 ying4	hard
+兼职	兼職	jian1 zhi2	to hold concurrent posts
+艰苦	艱苦	jian1 ku3	difficult
+艰难	艱難	jian1 nan2	difficult
+简便	簡便	jian3 bian4	simple and convenient
+简称	簡稱	jian3 cheng1	to be abbreviated to
+简化	簡化	jian3 hua4	to simplify
+简体	簡體	jian3 ti3	simplified form of Chinese characters, as opposed to traditional form 繁體|繁体[fan2 ti3]
+检讨	檢討	jian3 tao3	to examine or inspect
+贱	賤	jian4	inexpensive
+溅	濺	jian4	to splash
+见解	見解	jian4 jie3	opinion
+见识	見識	jian4 shi4	to gain first-hand knowledge of sth
+见证	見證	jian4 zheng5	to be witness to
+健壮	健壯	jian4 zhuang4	robust
+将军	將軍	jiang1 jun1	general
+奖励	獎勵	jiang3 li4	to reward
+奖赏	獎賞	jiang3 shang3	reward
+奖状	獎狀	jiang3 zhuang4	prize certificate
+讲理	講理	jiang3 li3	to argue
+讲习	講習	jiang3 xi2	to lecture
+讲义	講義	jiang3 yi4	teaching materials
+讲座	講座	jiang3 zuo4	a course of lectures
+交错	交錯	jiao1 cuo4	to crisscross
+交货	交貨	jiao1 huo4	to deliver goods
+交谈	交談	jiao1 tan2	to discuss
+脚本	腳本	jiao3 ben3	script
+搅和	攪和	jiao3 huo5	to mix (up)
+轿车	轎車	jiao4 che1	enclosed carriage for carrying passengers
+教诲	教誨	jiao4 hui3	to instruct
+教员	教員	jiao4 yuan2	teacher
+较量	較量	jiao4 liang4	to pit oneself against sb
+阶层	階層	jie1 ceng2	hierarchy
+阶级	階級	jie1 ji2	(social) class
+接连	接連	jie1 lian2	on end
+接纳	接納	jie5 a4	to admit (to membership)
+接下来	接下來	jie1 xia4 lai2	to accept
+揭晓	揭曉	jie1 xiao3	to announce publicly
+洁白	潔白	jie2 bai2	spotlessly white
+节俭	節儉	jie2 jian3	frugal
+节庆	節慶	jie2 qing4	festival
+结实	結實	jie2 shi5	to bear fruit
+结业	結業	jie2 ye4	to finish school, esp. a short course
+结缘	結緣	jie2 yuan2	to form ties
+捷运	捷運	jie2 yun4	rapid transit
+解说	解說	jie3 shuo1	to explain
+解体	解體	jie3 ti3	to break up into components
+解脱	解脫	jie3 tuo1	to untie
+解约	解約	jie3 yue1	to terminate an agreement
+届时	屆時	jie4 shi2	when the time comes
+戒备	戒備	jie4 bei4	to take precautions
+借贷	借貸	jie4 dai4	to borrow or lend money
+金钱	金錢	jin1 qian2	money
+金鱼	金魚	jin1 yu2	goldfish
+津贴	津貼	jin1 tie1	allowance
+紧凑	緊湊	jin3 cou4	compact
+紧密	緊密	jin3 mi4	inseparably close
+紧缩	緊縮	jin3 suo1	(economics) to reduce
+谨慎	謹慎	jin3 shen4	cautious
+劲	勁	jin4	strength
+进场	進場	jin4 chang3	to go into
+进度	進度	jin4 du4	pace
+进而	進而	jin4 er2	and then (what follows next)
+进攻	進攻	jin4 gong1	to attack
+进化	進化	jin4 hua4	evolution
+进军	進軍	jin4 jun1	to march
+进修	進修	jin4 xiu1	to undertake advanced studies
+进展	進展	jin4 zhan3	to make headway
+晋级	晉級	jin4 ji2	to advance in rank
+精华	精華	jing1 hua2	best feature
+精致	精緻	jing1 zhi4	delicate
+经典	經典	jing1 dian3	the classics
+经书	經書	jing1 shu1	classic books in Confucianism
+惊惶	驚惶	jing1 huang2	panic-stricken
+惊奇	驚奇	jing1 qi2	to be amazed
+惊喜	驚喜	jing1 xi3	nice surprise
+惊险	驚險	jing1 xian3	thrilling
+鲸鱼	鯨魚	jing1 yu2	whale
+警报	警報	jing3 bao4	(fire) alarm
+警觉	警覺	jing3 jue2	to be on guard
+警卫	警衛	jing3 wei4	to stand guard over
+景观	景觀	jing3 guan1	landscape
+景气	景氣	jing3 qi4	(of economy, business etc) flourishing
+静脉	靜脈	jing4 mai4	vein
+静态	靜態	jing4 tai4	static
+竞赛	競賽	jing4 sai4	race
+竞选	競選	jing4 xuan3	to take part in an election
+纠纷	糾紛	jiu1 fen1	dispute
+酒馆	酒館	jiu3 guan3	tavern
+就绪	就緒	jiu4 xu4	to be ready
+救济	救濟	jiu4 ji4	emergency relief
+沮丧	沮喪	ju3 sang4	dispirited
+举例	舉例	ju3 li4	to give an example
+举止	舉止	ju3 zhi3	bearing
+举重	舉重	ju3 zhong4	to lift weights
+据悉	據悉	ju4 xi1	according to reports
+捐献	捐獻	juan1 xian4	to donate
+捐赠	捐贈	juan1 zeng4	to contribute (as a gift)
+决赛	決賽	jue2 sai4	finals (of a competition)
+决议	決議	jue2 yi4	resolution
+抉择	抉擇	jue2 ze2	to choose (literary)
+绝大多数	絕大多數	jue2 da4 duo1 shu4	absolute majority
+绝迹	絕跡	jue2 ji1	to be eradicated
+均匀	均勻	jun1 yun2	even
+军备	軍備	jun1 bei4	(military) arms
+军阀	軍閥	jun1 fa2	military clique
+军官	軍官	jun1 guan1	officer (military)
+军舰	軍艦	jun1 jian4	warship
+开办	開辦	kai1 ban4	to open
+开导	開導	kai1 dao3	to talk sb round
+开动	開動	kai1 dong4	to start
+开饭	開飯	kai1 fan4	to serve a meal
+开口	開口	kai1 kou3	to open one's mouth
+开阔	開闊	kai1 kuo4	wide
+开路	開路	kai1 lu4	to open up a path
+开幕	開幕	kai1 mu4	to open (a conference)
+开盘	開盤	kai1 pan2	to commence trading (stock market)
+开辟	開闢	kai1 pi4	to open up
+开启	開啟	kai1 qi3	to open
+开头	開頭	kai1 tou2	beginning
+开销	開銷	kai1 xiao1	to pay (expenses)
+开业	開業	kai1 ye4	to open a business
+开展	開展	kai1 zhan3	to launch
+开张	開張	kai1 zhang1	to open a business
+康复	康復	kang1 fu4	to recuperate
+抗争	抗爭	kang4 zheng1	to resist
+考场	考場	kao3 chang3	exam room
+考验	考驗	kao3 yan4	to test
+刻画	刻畫	ke4 hua4	to portray
+苛责	苛責	ke1 ze2	to criticize harshly
+可观	可觀	ke3 guan1	considerable
+可见	可見	ke3 jian4	it can clearly be seen (that this is the case)
+客机	客機	ke4 ji1	passenger plane
+课业	課業	ke4 ye4	lesson
+吭声	吭聲	keng1 sheng1	to utter a word
+空旷	空曠	kong1 kuang4	spacious and empty
+空难	空難	kong1 nan4	air crash
+空谈	空談	kong1 tan2	prattle
+空运	空運	kong1 yun4	air transport
+恐吓	恐嚇	kong3 he4	to threaten
+恐惧	恐懼	kong3 ju4	to be frightened
+口头	口頭	kou3 tou2	oral
+苦难	苦難	ku3 nan4	suffering
+苦恼	苦惱	kun3 ao3	vexed
+库存	庫存	ku4 cun2	property or cash held in reserve
+夸耀	誇耀	kua1 yao4	to brag about
+宽广	寬廣	kuan1 guang3	wide
+宽阔	寬闊	kuan1 kuo4	expansive
+狂风	狂風	kuang2 feng1	gale
+矿产	礦產	kuang4 chan3	minerals
+矿工	礦工	kuang4 gong1	miner
+昆虫	昆蟲	kun1 chong2	insect
+困扰	困擾	kun4 rao3	to perplex
+扩建	擴建	kuo4 jian4	to extend (a building, an airport runway etc)
+扩散	擴散	kuo4 san4	to spread
+扩张	擴張	kuo4 zhang1	expansion
+腊月	臘月	la4 yue4	twelfth lunar month
+来宾	來賓	lai2 bin1	guest
+来得	來得	lai2 de5	to emerge (from a comparison)
+来客	來客	lai2 ke4	guest
+栏	欄	lan2	fence
+拦	攔	lan2	to block sb's path
+懒惰	懶惰	lan3 duo4	idle
+懒散	懶散	lan3 san3	inactive
+朗读	朗讀	lang3 du2	to read aloud
+朗诵	朗誦	lang3 song4	to read aloud with expression
+劳改	勞改	lao2 gai3	reform through labor
+劳累	勞累	lao2 lei4	tired
+老天爷	老天爺	lao3 tian1 ye2	God
+老头儿	老頭兒	lao3 tou2 r5	see 老頭子|老头子[lao3 tou2 zi5]
+老乡	老鄉	lao3 xiang1	fellow townsman
+雷达	雷達	lei2 da2	radar (loanword)
+累积	累積	lei3 ji1	to accumulate
+类型	類型	lei4 xing2	type
+冷冻	冷凍	leng3 dong4	to freeze
+冷门	冷門	leng3 men2	a neglected branch (of arts, science, sports etc)
+罹难	罹難	li2 nan4	to die in an accident or disaster
+理财	理財	li3 cai2	financial management
+理所当然	理所當然	li3 suo3 dang1 ran2	as it should be by rights (idiom); proper and to be expected as a matter of course
+理学	理學	li3 xue2	School of Principle
+礼服	禮服	li3 fu2	ceremonial robe
+礼节	禮節	li3 jie2	etiquette
+力学	力學	li4 xue2	mechanics
+立国	立國	li4 guo2	to found a country
+立体	立體	li4 ti3	three-dimensional
+历届	歷屆	li4 jie4	all previous (meetings, sessions etc)
+历来	歷來	li4 lai2	always
+历年	歷年	lin4 an2	over the years
+联盟	聯盟	lian2 meng2	alliance
+联系	聯繫	lian2 xi4	connection
+联想	聯想	lian2 xiang3	to associate (cognitively)
+连带	連帶	lian2 dai4	to be related
+连结	連結	lian2 jie2	variant of 聯結|联结[lian2 jie2]
+连任	連任	lian2 ren4	to continue in (a political) office
+连线	連線	lian2 xian4	electrical lead
+廉价	廉價	lian2 jia4	cheaply-priced
+廉洁	廉潔	lian2 jie2	honest
+脸庞	臉龐	lian3 pang2	face
+脸谱	臉譜	lian3 pu3	Facebook
+良机	良機	liang2 ji1	a good chance
+两极	兩極	liang3 ji2	the two poles
+两口子	兩口子	liang3 kou3 zi5	husband and wife
+辽阔	遼闊	liao2 kuo4	vast
+列车	列車	lie4 che1	(railway) train
+列国	列國	lie4 guo2	various countries
+猎人	獵人	lie4 ren2	hunter
+临床	臨床	lin2 chuang2	clinical
+邻里	鄰里	lin2 li3	neighbor
+铃	鈴	ling2	(small) bell
+灵感	靈感	ling2 gan3	inspiration
+灵验	靈驗	ling2 yan4	efficacious
+领队	領隊	ling3 dui4	to lead a group
+领会	領會	ling3 hui4	to understand
+领悟	領悟	ling3 wu4	to understand
+流传	流傳	liu2 chuan2	to spread
+柳树	柳樹	liu3 shu4	willow
+笼子	籠子	long2 zi5	cage
+笼罩	籠罩	long2 zhao4	to envelop
+垄断	壟斷	long3 duan4	to enjoy market dominance
+楼房	樓房	lou2 fang2	a building of two or more stories
+炉子	爐子	lu2 zi5	stove
+陆地	陸地	lu4 di4	dry land (as opposed to the sea)
+路过	路過	lu4 guo4	to pass by or through
+录影	錄影	lu4 ying3	to videotape
+录影机	錄影機	lu4 ying3 ji1	camcorder
+轮廓	輪廓	lun2 kuo4	an outline
+伦理	倫理	lun2 li3	ethics
+沦陷	淪陷	lun2 xian4	to fall into enemy hands
+论点	論點	lun4 dian3	argument
+啰嗦	囉嗦	luo1 suo5	long-winded
+锣	鑼	luo2	gong
+逻辑	邏輯	luo2 ji2	logic (loanword)
+落选	落選	luo4 xuan3	to fail to be chosen (or elected)
+骆驼	駱駝	luo4 tuo5	camel
+驴	驢	lü2	donkey
+铝	鋁	lü3	aluminum (chemistry)
+旅费	旅費	lü3 fei4	travel expenses
+履历	履歷	lü3 li4	background (academic and work)
+马铃薯	馬鈴薯	ma3 ling2 shu3	potato
+买主	買主	mai3 zhu3	customer
+迈	邁	mai4	to take a step
+迈进	邁進	mai4 jin4	to step in
+麦子	麥子	mai4 zi5	wheat
+卖座	賣座	mai4 zuo4	(of a movie, show etc) to attract large audiences
+瞒	瞞	man2	to conceal from
+蛮横	蠻橫	man2 heng4	rude and unreasonable
+满怀	滿懷	man3 huai2	to have one's heart filled with
+漫长	漫長	man4 chang2	very long
+盲从	盲從	mang2 cong2	to follow blindly
+冒险	冒險	mao4 xian3	to take risks
+眉头	眉頭	mei2 tou2	brows
+媒体	媒體	mei2 ti3	media, esp. news media
+美满	美滿	mei3 man3	happy
+闷	悶	men1	stuffy
+闷热	悶熱	men1 re4	sultry
+门户	門戶	men2 hu4	door
+梦见	夢見	meng4 jian4	to dream about (sth or sb)
+谜	謎	mi2	riddle
+谜语	謎語	mi2 yu3	riddle
+迷宫	迷宮	mi2 gong1	maze
+迷恋	迷戀	mi2 lian4	to be infatuated with
+弥补	彌補	mi2 bu3	to complement
+名额	名額	min2 ge2	quota
+名号	名號	ming2 hao4	name
+名气	名氣	ming2 qi4	reputation
+名胜	名勝	ming2 sheng4	a place famous for its scenery or historical relics
+名声	名聲	ming2 sheng1	reputation
+绵延	綿延	mian2 yan2	continuous (esp. of mountain ranges)
+免税	免稅	mian3 shui4	not liable to taxation (of monastery, imperial family etc)
+面谈	面談	mian4 tan2	face-to-face meeting
+描绘	描繪	miao2 hui4	to describe
+民营	民營	min2 ying2	privately run (i.e. by a company, not the state)
+模范	模範	mo2 fan4	model
+魔术	魔術	mo2 shu4	magic
+没落	沒落	mo4 luo4	to decline
+没收	沒收	mo4 shou1	to confiscate
+漠视	漠視	mo4 shi4	to ignore
+谋生	謀生	mou2 sheng1	to seek one's livelihood
+亩	畝	mu3	classifier for fields
+母语	母語	mu3 yu3	native language
+目击	目擊	mu4 ji2	to see with one's own eyes
+牧场	牧場	mu4 chang3	pasture
+纳闷	納悶	na4 men4	puzzled
+纳入	納入	na4 ru4	to bring into
+纳税	納稅	na4 shui4	to pay taxes
+南极洲	南極洲	nan2 ji2 zhou1	Antarctica
+难度	難度	nan2 du4	trouble
+难关	難關	nan2 guan1	difficulty
+难免	難免	nan2 mian3	hard to avoid
+难题	難題	nan2 ti2	difficult problem
+难民	難民	nan4 min2	refugee
+脑海	腦海	nao3 hai3	the mind
+脑力	腦力	nao3 li4	mental capacity
+内阁	內閣	nei4 ge2	(government) cabinet
+内涵	內涵	nei4 han2	meaningful content
+内销	內銷	nei4 xiao1	to sell in the domestic market
+内在	內在	nei4 zai4	inner
+内战	內戰	nei4 zhan4	civil war
+内政	內政	nei4 zheng4	internal affairs (of a country)
+拟定	擬定	ni3 ding4	to draw up
+念头	念頭	nian4 tou5	thought
+凝结	凝結	ning2 jie2	to condense
+凝视	凝視	ning2 shi4	to gaze at
+扭转	扭轉	niu3 zhuan3	to reverse
+农具	農具	nong2 ju4	farm implements
+农田	農田	nong2 tian2	farmland
+农作物	農作物	nong2 zuo4 wu4	(farm) crops
+弄错	弄錯	nong4 cuo4	to err
+奴隶	奴隸	nu2 li4	slave
+怒气	怒氣	nu4 qi4	anger
+诺言	諾言	nuo4 yan2	promise
+欧洲	歐洲	ou1 zhou1	Europe
+拍马屁	拍馬屁	pai1 ma3 pi4	to flatter
+拍摄	拍攝	pai1 she4	to film
+排挤	排擠	pai2 ji3	to crowd out
+派对	派對	pai4 dui4	party (loanword)
+派头	派頭	pai4 tou2	manner
+旁听	旁聽	pang2 ting1	to visit (a meeting, class, trial etc)
+抛	拋	pao1	to throw
+抛弃	拋棄	pao1 qi4	to abandon
+培训	培訓	pei2 xun4	to cultivate
+配给	配給	pei4 ji3	to ration
+喷漆	噴漆	pen1 qi1	to spray paint or lacquer
+捧场	捧場	peng3 chang3	to cheer on (originally esp. as paid stooge)
+批发	批發	pi1 fa1	wholesale
+疲惫	疲憊	pi2 bei4	beaten
+贫苦	貧苦	pin2 ku3	poverty-stricken
+贫民	貧民	pin2 min2	poor people
+品种	品種	pin3 zhong3	breed
+平稳	平穩	ping2 wen3	smooth
+评估	評估	ping2 gu1	to evaluate
+评价	評價	ping2 jia4	to evaluate
+评论	評論	ping2 lun4	to comment on
+破产	破產	po4 chan3	to go bankrupt
+破获	破獲	po4 huo4	to uncover (a criminal plot)
+朴素	樸素	pu2 su4	plain and simple
+凄凉	淒涼	qi1 liang2	desolate (place)
+奇观	奇觀	qi2 guan1	spectacle
+奇异	奇異	qi2 yi4	fantastic
+期货	期貨	qi2 huo4	abbr. for 期貨合約|期货合约[qi1 huo4 he2 yue1], futures contract (finance)
+旗帜	旗幟	qi2 zhi4	ensign
+启发	啟發	qi3 fa1	to enlighten
+启示	啟示	qi3 shi4	to reveal
+启事	啟事	qi3 shi4	announcement (written, on billboard, letter, newspaper or website)
+起码	起碼	qi3 ma3	at the minimum
+气概	氣概	qi4 gai4	lofty quality
+气管	氣管	qi4 guan3	windpipe
+气派	氣派	qi4 pai5	imposing manner or style
+气势	氣勢	qi4 shi4	imposing manner
+气体	氣體	qi4 ti3	gas (i.e. gaseous substance)
+气压	氣壓	qi4 ya1	atmospheric pressure
+契机	契機	qi4 ji1	opportunity
+弃权	棄權	qi4 quan2	to abstain from voting
+恰当	恰當	qia4 dang4	appropriate
+洽谈	洽談	qia4 tan2	to discuss
+牵连	牽連	qian1 lian2	to implicate
+签署	簽署	qian1 shu4	to sign (an agreement)
+谦逊	謙遜	qian1 xun4	humble
+前辈	前輩	qian2 bei4	senior
+前后	前後	qian2 hou4	around
+潜藏	潛藏	qian2 cang2	hidden beneath the surface
+潜力	潛力	qian2 li4	potential
+虔诚	虔誠	qian2 cheng2	pious
+浅薄	淺薄	qian3 bo2	superficial
+浅显	淺顯	qian3 xian3	plain
+腔调	腔調	qiang1 diao4	accent
+墙角	牆角	qiang2 jiao3	corner (junction of two walls)
+强劲	強勁	qiang2 jing4	strong
+强求	強求	qiang3 qiu2	to insist on
+强权	強權	qiang2 quan2	power
+强壮	強壯	qiang2 zhuang4	strong
+翘	翹	qiao4	outstanding
+翘课	翹課	qiao4 ke4	to skip school
+切实	切實	qie4 shi2	feasible
+窃贼	竊賊	qie4 zei2	thief
+亲热	親熱	qin1 re4	affectionate
+亲身	親身	qin1 shen1	personal
+亲生	親生	qin1 sheng1	one's own (child) (i.e. one's child by birth)
+侵蚀	侵蝕	qin1 shi2	to erode
+侵袭	侵襲	qin1 xi2	to invade
+钦佩	欽佩	qin1 pei4	to admire
+勤奋	勤奮	qin2 fen4	hardworking
+清洁	清潔	qing1 jie2	clean
+清静	清靜	qing1 jing4	quiet
+清扫	清掃	qing1 sao3	to tidy up
+轻薄	輕薄	qing1 bo2	light (weight)
+轻蔑	輕蔑	qing1 mie4	to contempt
+轻易	輕易	qing1 yi4	easily
+情报	情報	qing2 bao4	information
+情妇	情婦	qing2 fu4	mistress
+情节	情節	qing2 jie2	plot
+情侣	情侶	qing2 lü3	sweethearts
+庆幸	慶幸	qing4 xing4	to rejoice
+求学	求學	qiu2 xue2	to seek knowledge
+趋势	趨勢	qu1 shi4	trend
+取缔	取締	qu3 di4	to suppress
+取样	取樣	qu3 yang4	to take a sample
+取悦	取悅	qu3 yue4	to try to please
+全盘	全盤	quan2 pan2	overall
+权力	權力	quan2 li4	power
+权威	權威	quan2 wei1	authority
+权益	權益	quan2 yi4	rights
+劝导	勸導	quan4 dao3	to advise
+劝告	勸告	quan4 gao4	to advise
+确保	確保	que4 bao3	to ensure
+确切	確切	que4 qie4	definite
+群岛	群島	qun2 dao3	group of islands
+饶	饒	rao2	rich
+热潮	熱潮	re4 chao2	upsurge
+热带	熱帶	re4 dai4	the tropics
+热量	熱量	re4 liang4	heat
+热水瓶	熱水瓶	re4 shui3 ping2	thermos bottle
+仁爱	仁愛	ren2 ai4	benevolence
+人祸	人禍	ren2 huo4	human disaster
+人际	人際	ren2 ji4	human relationships
+人选	人選	ren2 xuan3	choice of person
+认错	認錯	ren4 cuo4	to admit an error
+认定	認定	ren4 ding4	to maintain (that sth is true)
+日光灯	日光燈	ri4 guang1 deng1	fluorescent light
+容纳	容納	rong2 na4	to hold
+容许	容許	rong2 xu3	to permit
+荣誉	榮譽	rong2 yu4	honor
+柔软	柔軟	rou2 ruan3	soft
+肉体	肉體	rou4 ti3	physical body
+软弱	軟弱	ruan3 ruo4	weak
+软体	軟體	ruan3 ti3	software (Tw)
+撒谎	撒謊	sa1 huang3	to tell lies
+洒	灑	sa3	to sprinkle
+塞车	塞車	sai1 che1	traffic jam
+丧事	喪事	sang1 shi4	funeral arrangements
+丧生	喪生	sang4 sheng1	to die
+骚动	騷動	sao1 dong4	disturbance
+色泽	色澤	se4 ze2	color and luster
+刹	剎	sha1 che1	to brake
+沙哑	沙啞	sha1 ya3	hoarse
+山脉	山脈	shan1 mai4	mountain range
+闪电	閃電	shan3 dian4	lightning
+闪烁	閃爍	shan3 shuo4	flickering
+闪耀	閃耀	shan3 yao4	to glint
+擅长	擅長	shan4 chang2	to be good at
+伤口	傷口	shang1 kou3	wound
+伤亡	傷亡	shang1 wang2	casualties
+商讨	商討	shang1 tao3	to discuss
+上进	上進	shang4 jin4	to make progress
+上门	上門	shang4 men2	to drop in
+上瘾	上癮	shang4 yin3	to get into a habit
+上涨	上漲	shang4 zhang3	to rise
+烧香	燒香	shao1 xiang1	to burn incense
+设施	設施	she4 shi1	facilities
+设想	設想	she4 xiang3	to imagine
+射击	射擊	she4 ji2	to shoot
+社论	社論	she4 lun4	editorial (in a newspaper)
+社区	社區	she4 qu1	community
+摄取	攝取	she4 qu3	to absorb (nutrients etc)
+摄氏	攝氏	she4 shi4	Celsius
+摄影机	攝影機	she4 ying3 ji1	camera
+深奥	深奧	shen1 ao4	profound
+身为	身為	shen1 wei2	in the capacity of
+伸张	伸張	shen1 zhang1	to uphold (e.g. justice or virtue)
+审核	審核	shen3 he2	to audit
+审判	審判	shen3 pan4	a trial
+审慎	審慎	shen3 shen4	prudent
+审议	審議	shen3 yi4	deliberation
+渗入	滲入	shen4 ru4	to permeate
+生词	生詞	sheng1 ci2	new word (in textbook)
+生态	生態	sheng1 tai4	ecology
+升迁	升遷	sheng1 qian1	promote
+声称	聲稱	sheng1 cheng1	to claim
+声明	聲明	sheng1 ming2	to state
+声势	聲勢	sheng1 shi4	fame and power
+盛装	盛裝	sheng4 zhuang1	(of a receptacle etc) to contain
+胜地	勝地	sheng4 di4	well-known scenic spot
+圣贤	聖賢	sheng4 xian2	a sage
+失灵	失靈	shi1 ling2	out of order (of machine)
+失踪	失蹤	shi1 zong1	to be missing
+师范	師範	shi1 fan4	teacher-training
+尸体	屍體	shi1 ti3	dead body
+时差	時差	shi2 cha1	time difference
+时光	時光	shi2 guang1	time
+时节	時節	shi2 jie2	season
+时髦	時髦	shi2 mao2	in vogue
+时效	時效	shi2 xiao4	effectiveness for a given period of time
+实地	實地	shi2 di4	on-site
+实践	實踐	shi2 jian4	practice
+实况	實況	shi2 kuang4	live (e.g. broadcast or recording)
+实例	實例	shi2 li4	an actual example
+实习	實習	shi2 xi2	to practice
+实证	實證	shi2 zheng4	actual proof
+实质	實質	shi2 zhi2	substance
+使唤	使喚	shi3 huan4	to order sb about
+使节	使節	shi3 jie2	(diplomatic) envoy
+使劲	使勁	shi3 jing4	to exert all one's strength
+示范	示範	shi4 fan4	to demonstrate
+世间	世間	shi4 jian1	world
+试卷	試卷	shi4 juan4	examination paper
+试图	試圖	shi4 tu2	to attempt
+势必	勢必	shi4 bi4	to be bound to
+事变	事變	shi4 bian4	incident
+事态	事態	shi4 tai4	situation
+事务	事務	shi4 wu4	(political, economic etc) affairs
+释放	釋放	shi4 fang4	to release
+视为	視為	shi4 wei2	to view as
+适宜	適宜	shi4 yi2	suitable
+适中	適中	shi4 zhong1	moderate
+收费	收費	shou1 fei4	to charge a fee
+收买	收買	shou1 mai3	to purchase
+收缩	收縮	shou1 suo1	to pull back
+收听	收聽	shou1 ting1	to listen to (a radio broadcast)
+手册	手冊	shou3 ce4	manual
+手枪	手槍	shou3 qiang1	pistol
+手势	手勢	shou3 shi4	gesture
+守护	守護	shou3 hu4	to guard
+首领	首領	shou3 ling3	head
+首饰	首飾	shou3 shi4	jewelry
+首长	首長	shou3 zhang3	senior official
+受训	受訓	shou4 xun4	to receive training
+售货员	售貨員	shou4 huo4 yuan2	salesperson
+授课	授課	shou4 ke4	to teach
+狩猎	狩獵	shou4 lie4	to hunt
+寿星	壽星	shou4 xing1	god of longevity
+疏导	疏導	shu1 dao3	to dredge
+书本	書本	shu1 ben3	book
+书面	書面	shu1 mian4	in writing
+书写	書寫	shu1 xie3	to write
+舒畅	舒暢	shu1 chang4	happy
+输血	輸血	shu1 xie3	to transfuse blood
+束缚	束縛	shu4 fu2	to bind
+树苗	樹苗	shu4 miao2	sapling
+数据	數據	shu4 ju4	data
+双重	雙重	shuang1 chong2	double
+双打	雙打	shuang1 da3	doubles (in sports)
+水库	水庫	shui3 ku4	reservoir
+水蒸气	水蒸氣	shui3 zheng1 qi4	vapor
+顺从	順從	shun4 cong2	obedient
+顺应	順應	shun4 ying4	to comply
+瞬间	瞬間	shun4 jian1	in an instant
+说谎	說謊	shuo1 huang3	to lie
+说笑	說笑	shuo1 xiao4	to chat and laugh
+思维	思維	si1 wei2	(line of) thought
+丝毫	絲毫	si1 hao2	the slightest amount or degree
+赐	賜	si4	to confer
+松树	松樹	song1 shu4	pine
+怂恿	慫恿	song3 yong3	to instigate
+俗称	俗稱	su2 cheng1	commonly referred to as
+俗语	俗語	su2 yu3	common saying
+塑胶	塑膠	su4 jiao1	plastic
+诉苦	訴苦	su4 ku3	to grumble
+素质	素質	su4 zhi2	inner quality
+算术	算術	suan4 shu4	arithmetic
+虽说	雖說	sui1 shuo1	though
+随后	隨後	sui2 hou4	soon after
+随即	隨即	sui2 ji2	immediately
+随身	隨身	sui2 shen1	to (carry) on one's person
+随同	隨同	sui2 tong2	accompanying
+岁月	歲月	sui4 yue4	years
+损害	損害	sun3 hai4	harm
+损坏	損壞	sun3 huai4	to damage
+损伤	損傷	sun3 shang1	to harm
+缩小	縮小	suo1 xiao3	to reduce
+索赔	索賠	suo3 pei2	to ask for compensation
+琐碎	瑣碎	suo3 sui4	trifling
+踏实	踏實	ta4 shi2	firmly-based
+太极拳	太極拳	tai4 ji2 quan2	shadowboxing or Taiji, T'aichi or T'aichichuan
+态势	態勢	tai4 shi4	posture
+贪	貪	tan1	to have a voracious desire for
+贪心	貪心	tan1 xin1	greedy
+摊位	攤位	tan1 wei4	vendor's booth
+谈论	談論	tan2 lun4	to discuss
+弹性	彈性	tan2 xing4	flexibility
+探险	探險	tan4 xian3	to explore
+汤圆	湯圓	tang1 yuan2	boiled balls of glutinous rice flour, eaten during the Lantern Festival
+逃税	逃稅	tao2 shui4	to evade a tax
+套装	套裝	tao4 zhuang1	outfit or suit (of clothes)
+特区	特區	te4 qu1	special administrative region
+特权	特權	te4 quan2	prerogative
+特约	特約	te4 yue1	specially engaged
+特征	特徵	te4 zheng1	characteristic
+疼爱	疼愛	te5 gai4	to love dearly
+提议	提議	ti2 yi4	proposal
+体操	體操	ti3 cao1	gymnastic
+体格	體格	ti3 ge2	bodily health
+体积	體積	ti3 ji1	volume
+体谅	體諒	ti3 liang5	to empathize
+体面	體面	ti3 mian4	dignity
+体系	體系	ti3 xi4	system
+体质	體質	ti3 zhi2	constitution
+天敌	天敵	tian1 di2	predator
+天然气	天然氣	tian1 ran2 qi4	natural gas
+天灾	天災	tian1 zai1	natural disaster
+田径	田徑	tian2 jing4	track and field (athletics)
+调和	調和	tiao2 he2	harmonious
+调节	調節	tiao2 jie2	to adjust
+调皮	調皮	tiao2 pi2	naughty
+条例	條例	tiao2 li4	regulations
+听写	聽寫	ting1 xie3	(of a pupil) to write down (in a dictation exercise)
+停顿	停頓	ting2 dun4	to halt
+停滞	停滯	ting2 zhi4	stagnation
+通报	通報	tong1 bao4	to inform
+通车	通車	tong1 che1	to open to traffic (e.g. new bridge, rail line etc)
+通称	通稱	tong1 cheng1	generic term
+通货膨胀	通貨膨脹	tong1 huo4 peng2 zhang4	inflation
+通缉	通緝	tong1 qi4	to order the arrest of sb as criminal
+同乡	同鄉	tong2 xiang1	person from the same village, town, or province
+同性恋	同性戀	tong2 xing4 lian4	homosexuality
+同业	同業	tong2 ye4	same trade or business
+统统	統統	tong3 tong3	totally
+统制	統制	tong3 zhi4	to control
+偷懒	偷懶	tou1 lan3	to goof off
+投机	投機	tou2 ji1	to speculate (on financial markets)
+突击	突擊	tu2 ji2	sudden and violent attack
+图表	圖表	tu2 biao3	chart
+图画	圖畫	tu2 hua4	drawing
+图腾	圖騰	tu2 teng2	totem (loanword)
+团聚	團聚	tuan2 ju4	to reunite
+团员	團員	tuan2 yuan2	member
+推测	推測	tui1 ce4	speculation
+推选	推選	tui1 xuan3	to elect
+脱身	脫身	tuo1 shen1	to get away
+脱手	脫手	tuo1 shou3	(not of regular commerce) to sell or dispose of (goods etc)
+外号	外號	wai4 hao4	nickname
+外贸	外貿	wai4 mao4	foreign trade
+外销	外銷	wai4 xiao1	to export
+外资	外資	wai4 zi1	foreign investment
+弯曲	彎曲	wan1 qu1	to bend
+完备	完備	wan2 bei4	faultless
+顽强	頑強	wan2 qiang2	tenacious
+万分	萬分	wan4 fen1	very much
+万事	萬事	wan4 shi4	all things
+万岁	萬歲	wan4 sui4	Long live (the king, the revolution etc)!
+万万	萬萬	wan4 wan4	absolutely
+万物	萬物	wan4 wu4	all living things
+亡国	亡國	wang2 guo2	(of a nation) to be destroyed
+往来	往來	wang3 lai2	dealings
+威风	威風	wei1 feng1	might
+萎缩	萎縮	wei1 suo1	to wither
+为人	為人	wei2 ren2	to conduct oneself
+为生	為生	wei2 sheng1	to make a living
+为首	為首	wei2 shou3	head
+为止	為止	wei2 zhi3	until
+违背	違背	wei2 bei4	to go against
+违约	違約	wei2 yue1	to break a promise
+围巾	圍巾	wei2 jin1	scarf
+围墙	圍牆	wei2 qiang2	perimeter wall
+围绕	圍繞	wei2 rao4	to revolve around
+维生素	維生素	wei2 sheng1 su4	vitamin
+温带	溫帶	wen1 dai4	temperate zone
+温泉	溫泉	wen1 quan2	hot spring
+温习	溫習	wen1 xi2	to review (a lesson etc)
+温驯	溫馴	wen1 xun2	docile
+文坛	文壇	wen2 tan2	literary circles
+文献	文獻	wen2 xian4	document
+闻名	聞名	wen2 ming2	well-known
+稳健	穩健	wen3 jian4	firm
+紊乱	紊亂	wen4 luan4	disorder
+问世	問世	wen4 shi4	to be published
+乌龟	烏龜	wu1 gui1	tortoise
+乌龙茶	烏龍茶	wu1 long2 cha2	oolong tea
+乌鸦	烏鴉	wu1 ya1	crow
+无比	無比	wu2 bi3	incomparable
+无线电	無線電	wu2 xian4 dian4	wireless
+无形	無形	wu2 xing2	incorporeal
+无疑	無疑	wu2 yi2	no doubt
+武装	武裝	wu3 zhuang1	arms
+物产	物產	wu4 chan3	products
+物体	物體	wu4 ti3	object
+物资	物資	wu4 zi1	goods
+误差	誤差	wu4 cha1	difference
+误解	誤解	wu4 jie3	to misunderstand
+务实	務實	wu4 shi2	pragmatic
+西医	西醫	xi1 yi1	Western medicine
+锡	錫	xi2	tin (chemistry)
+袭击	襲擊	xi2 ji2	attack (esp. surprise attack)
+习题	習題	xi2 ti2	(schoolwork) exercise
+洗礼	洗禮	xi3 li3	baptism (lit. or fig.)
+喜气	喜氣	xi3 qi4	hilarity
+喜悦	喜悅	xi3 yue4	happy
+戏曲	戲曲	xi4 qu3	Chinese opera
+峡谷	峽谷	xia2 gu3	canyon
+狭小	狹小	xia2 xiao3	narrow
+狭窄	狹窄	xia2 zhai3	narrow
+下笔	下筆	xia4 bi3	to put pen to paper
+先后	先後	xian1 hou4	early or late
+先驱	先驅	xian1 qu1	pioneer
+鲜明	鮮明	xian1 ming2	bright
+纤维	纖維	xian1 wei2	fiber
+显现	顯現	xian3 xian4	appearance
+宪法	憲法	xian4 fa3	constitution (of a country)
+线路	線路	xian4 lu4	line
+献身	獻身	xian4 shen1	to commit one's energy to
+现今	現今	xian4 jin1	now
+现行	現行	xian4 xing2	to be in effect
+现状	現狀	xian4 zhuang4	current situation
+相传	相傳	xiang1 chuan2	to pass on
+相继	相繼	xiang1 ji4	in succession
+乡土	鄉土	xiang1 tu3	native soil
+镶	鑲	xiang1	to inlay
+想开	想開	xiang3 kai1	to get over (a shock, bereavement etc)
+响亮	響亮	xiang3 liang4	loud and clear
+向导	嚮導	xiang4 dao3	guide
+向往	嚮往	xiang4 wang3	to yearn for
+象征	象徵	xiang4 zheng1	emblem
+潇洒	瀟灑	xiao1 sa3	confident and at ease
+逍遥	逍遙	xiao1 yao2	free and unfettered
+小贩	小販	xiao3 fan4	peddler
+效劳	效勞	xiao4 lao2	to serve (in some capacity)
+协办	協辦	xie2 ban4	to assist
+协定	協定	xie2 ding4	(reach an) agreement
+协会	協會	xie2 hui4	an association
+协商	協商	xie2 shang1	to consult with
+协调	協調	xie2 tiao2	to coordinate
+协议	協議	xie2 yi4	agreement
+血迹	血跡	xie3 ji1	bloodstain
+血压	血壓	xie3 ya1	blood pressure
+写实	寫實	xie3 shi2	realism
+写作	寫作	xie3 zuo4	to write
+泄气	洩氣	xie4 qi4	to leak (gas)
+心爱	心愛	xin1 ai4	beloved
+心软	心軟	xin1 ruan3	to be softhearted
+心态	心態	xin1 tai4	attitude (of the heart)
+新颖	新穎	xin1 ying3	lit. new bud
+信赖	信賴	xin4 lai4	to trust
+兴建	興建	xing1 jian4	to build
+兴隆	興隆	xing1 long2	prosperous
+兴起	興起	xing1 qi3	to rise
+形势	形勢	xing2 shi4	circumstances
+形态	形態	xing2 tai4	shape
+形体	形體	xing2 ti3	figure
+型态	型態	xing2 tai4	form
+兴致	興致	xing4 zhi4	mood
+修补	修補	xiu1 bu3	to mend
+修订	修訂	xiu1 ding4	to revise
+修养	修養	xiu1 yang3	accomplishment
+修筑	修築	xiu1 zhu2	to build
+绣	繡	xiu4	to embroider
+虚拟	虛擬	xun1	to imagine
+虚心	虛心	xu1 xin1	open-minded
+许久	許久	xu3 jiu3	for a long time
+许可	許可	xu3 ke3	to allow
+叙述	敘述	xu4 shu4	to relate (a story or information)
+宣称	宣稱	xuan1 cheng1	to assert
+宣扬	宣揚	xuan1 yang2	to proclaim
+旋转	旋轉	xuan2 zhuan3	to rotate
+悬殊	懸殊	xuan2 shu1	widely different
+悬崖	懸崖	xuan2 ya5	precipice
+选拔	選拔	xuan3 ba2	to select the best
+选购	選購	xuan3 gou4	to select and purchase
+选民	選民	xuan3 min2	voter
+选票	選票	xuan3 piao4	a vote
+选修	選修	xuan3 xiu1	optional course (in school)
+学分	學分	xue2 fen1	course credit
+学科	學科	xue2 ke1	subject
+学年	學年	xue5 an2	academic year
+学识	學識	xue2 shi4	erudition
+学说	學說	xue2 shuo1	theory
+学徒	學徒	xue2 tu2	apprentice
+学员	學員	xue2 yuan2	student
+学制	學制	xue2 zhi4	educational system
+巡逻	巡邏	xun2 luo2	to patrol (police, army or navy)
+巡视	巡視	xun2 shi4	to patrol
+询问	詢問	xun2 wen4	to inquire
+鸦片	鴉片	ya1 pian4	opium (loanword)
+压岁钱	壓歲錢	ya1 sui4 qian2	money given to children as new year present
+压缩	壓縮	ya1 suo1	to compress
+压制	壓制	ya1 zhi4	to suppress
+亚军	亞軍	ya4 jun1	second place (in a sports contest)
+亚洲	亞洲	ya4 zhou1	Asia
+言论	言論	yan2 lun4	expression of opinion
+延迟	延遲	yan2 chi2	to delay
+延误	延誤	yan2 wu4	to delay
+延续	延續	yan2 xu4	to continue
+沿袭	沿襲	yan2 xi2	to carry on as before
+严禁	嚴禁	yan2 jin4	to strictly prohibit
+严厉	嚴厲	yan2 li4	severe
+严密	嚴密	yan2 mi4	strict
+演变	演變	yan3 bian4	to develop
+演说	演說	yan3 shuo1	speech
+演习	演習	yan3 xi2	maneuver
+燕窝	燕窩	yan4 wo1	swallow's nest
+养分	養分	yang3 fen4	nutrient
+养老	養老	yang3 lao3	to provide for the elderly (family members)
+养育	養育	yang3 yu4	to rear
+窑	窯	yao2	kiln
+摇晃	搖晃	yao2 huang5	to rock
+谣言	謠言	yao2 yan5	rumor
+遥远	遙遠	yao2 yuan3	distant
+要点	要點	yao4 dian3	main point
+药品	藥品	yao4 pin3	medicaments
+业绩	業績	ye4 ji1	achievement
+依旧	依舊	yi1 jiu4	as before
+依赖	依賴	yi1 lai4	to depend on
+医疗	醫療	yi1 liao2	medical treatment
+医术	醫術	yi1 shu4	medical expertise
+医药	醫藥	yi1 yao4	medical care and medicines
+一贯	一貫	yi1 guan4	consistent
+仪表	儀表	yi2 biao3	appearance
+遗产	遺產	yi2 chan3	heritage
+遗传	遺傳	yi2 chuan2	heredity
+遗憾	遺憾	yi2 han4	regret
+遗留	遺留	yi2 liu2	to leave behind
+遗弃	遺棄	yi2 qi4	to leave
+遗体	遺體	yi2 ti3	remains (of a dead person)
+遗忘	遺忘	yi2 wang4	to become forgotten
+遗志	遺志	yi2 zhi4	the mission in life of a deceased person, left to others to carry on
+遗址	遺址	yi2 zhi3	ruins
+疑虑	疑慮	yi2 lü4	hesitation
+一连串	一連串	yi1 lian2 chuan4	a succession of
+液体	液體	ye4 ti3	liquid
+意图	意圖	yi4 tu2	intent
+异常	異常	yi4 chang2	exceptional
+异乡	異鄉	yi4 xiang1	foreign land
+议定	議定	yi4 ding4	to reach an agreement
+议论	議論	yi4 lun4	to comment
+议题	議題	yi4 ti2	topic of discussion
+议员	議員	yi4 yuan2	member (of a legislative body)
+阴谋	陰謀	yin1 mou2	plot
+阴影	陰影	yin1 ying3	(lit. and fig.) shadow
+银幕	銀幕	yin2 mu4	movie screen
+银色	銀色	yin2 se4	silver (color)
+银子	銀子	yin2 zi5	money
+引导	引導	yin3 dao3	to guide
+引进	引進	yin3 jin4	to recommend
+隐藏	隱藏	yin3 cang2	to hide
+隐士	隱士	yin3 shi4	hermit
+隐约	隱約	yin3 yue1	vague
+印证	印證	yin4 zheng4	to seal
+樱桃	櫻桃	ying1 tao2	cherry
+英语	英語	ying1 yu3	English (language)
+鹰	鷹	ying1	eagle
+营地	營地	ying2 di4	camp
+营造	營造	ying2 zao4	to build (housing)
+硬体	硬體	ying4 ti3	(computer) hardware
+应变	應變	ying4 bian4	to meet a contingency
+应酬	應酬	ying4 chou2	social niceties
+应急	應急	ying4 ji2	to respond to an emergency
+应验	應驗	ying4 yan4	to come true
+应征	應徵	ying4 zheng1	to apply (for a job)
+涌	湧	yong3	to bubble up
+踊跃	踴躍	yong3 yue4	to leap
+用户	用戶	yong4 hu4	user
+悠闲	悠閒	you1 xian2	leisurely
+优待	優待	you1 dai4	preferential treatment
+优势	優勢	you1 shi4	superiority
+优先	優先	you1 xian1	to have priority
+优异	優異	you1 yi4	exceptional
+铀	鈾	you4	uranium (chemistry)
+由来	由來	you2 lai2	origin
+游览	遊覽	you2 lan3	to go sightseeing
+油条	油條	you2 tiao2	youtiao (deep-fried breadstick)
+友爱	友愛	you3 ai4	friendly affection
+有机	有機	you3 ji1	organic
+有为	有為	you3 wei2	promising
+有缘	有緣	you3 yuan2	related
+诱惑	誘惑	you4 huo4	to entice
+舆论	輿論	yu2 lun4	public opinion
+渔民	漁民	yu2 min2	fisherman
+与会	與會	yu4 hui4	to participate in a meeting
+语文	語文	yu3 wen2	literature and language
+预测	預測	yu4 ce4	to forecast
+预防	預防	yu4 fang2	to prevent
+预告	預告	yu4 gao4	to forecast
+预估	預估	yu4 gu1	to estimate
+预赛	預賽	yu4 sai4	preliminary competition
+预约	預約	yu4 yue1	booking
+园林	園林	yuan2 lin2	gardens
+元气	元氣	yuan2 qi4	strength
+原状	原狀	yuan2 zhuang4	previous condition
+原子弹	原子彈	yuan2 zi3 dan4	atom bomb
+远景	遠景	yuan3 jing3	prospect
+约束	約束	yue1 shu4	to restrict
+乐队	樂隊	yue4 dui4	band
+运行	運行	yun4 xing2	to move along one's course (of celestial bodies etc)
+孕妇	孕婦	yun4 fu4	pregnant woman
+酝酿	醞釀	yun4 niang4	(of alcohol) to ferment
+灾祸	災禍	zai1 huo4	disaster
+灾情	災情	zai1 qing2	disastrous situation
+在场	在場	zai4 chang3	to be present
+赞助	贊助	zan4 zhu4	to support
+赞叹	讚嘆	zan4 tan4	to exclaim in admiration
+赃物	贓物	zang1 wu4	booty
+责备	責備	ze2 bei4	to blame
+增进	增進	zeng1 jin4	to promote
+增强	增強	zeng1 qiang2	to increase
+炸药	炸藥	zha4 yao4	explosive (material)
+盏	盞	zhan3	a small cup
+展现	展現	zhan3 xian4	to come out
+崭新	嶄新	zhan3 xin1	brand new
+颤抖	顫抖	zhan4 dou3	to shudder
+战火	戰火	zhan4 huo3	conflagration
+战机	戰機	zhan4 ji1	opportunity in a battle
+战乱	戰亂	zhan4 luan4	chaos of war
+战略	戰略	zhan4 lüe4	strategy
+战胜	戰勝	zhan4 sheng4	to prevail over
+战士	戰士	zhan4 shi4	fighter
+战术	戰術	zhan4 shu4	tactics
+战线	戰線	zhan4 xian4	battle line
+战友	戰友	zhan4 you3	comrade-in-arms
+战战兢兢	戰戰兢兢	zhan4 zhan4 jing1 jing1	trembling with fear
+张开	張開	zhang1 kai1	to open up
+张贴	張貼	zhang1 tie1	to post (a notice)
+长子	長子	zhang3 zi3	eldest son
+帐篷	帳篷	zhang4 peng2	tent
+朝气	朝氣	zhao1 qi4	vitality
+着想	著想	zhao2 xiang3	to give thought (to others)
+找寻	找尋	zhao3 xun2	to look for
+沼泽	沼澤	zhao3 ze2	marsh
+折腾	折騰	zhe1 teng5	to toss from side to side (e.g. sleeplessly)
+针灸	針灸	zhen1 jiu3	acupuncture and moxibustion
+诊断	診斷	zhen3 duan4	diagnosis
+诊所	診所	zhen3 suo3	clinic
+镇定	鎮定	zhen4 ding4	calm
+镇压	鎮壓	zhen4 ya1	suppression
+振动	振動	zhen4 dong4	to vibrate
+震惊	震驚	zhen4 jing1	to shock
+阵营	陣營	zhen4 ying2	group of people
+蒸发	蒸發	zheng1 fa1	to evaporate
+蒸气	蒸氣	zheng1 qi4	vapor
+争辩	爭辯	zheng1 bian4	a dispute
+争夺	爭奪	zheng1 duo2	to fight over
+争气	爭氣	zheng1 qi4	to work hard for sth
+争议	爭議	zheng1 yi4	controversy
+征收	徵收	zheng1 shou1	to levy (a fine)
+挣扎	掙扎	zheng1 zha2	to struggle
+整顿	整頓	zheng3 dun4	to tidy up
+整体	整體	zheng3 ti3	whole entity
+正当	正當	zheng4 dang1	timely
+正统	正統	zheng4 tong3	Zhengtong Emperor, reign name of sixth Ming Emperor Zhu Qizhen 朱祁鎮|朱祁镇[Zhu1 Qi2 zhen4] (1427-1464), reigned 1435-1449, Temple name Yingzong 英宗[Ying1 zong1]
+正义	正義	zheng4 yi4	justice
+政绩	政績	zheng4 ji1	(political) achievements
+政见	政見	zheng4 jian4	political views
+政权	政權	zheng4 quan2	regime
+证券	證券	zheng4 quan4	negotiable security (financial)
+证人	證人	zheng4 ren2	witness
+之内	之內	zhi5 ei4	inside
+支撑	支撐	zhi1 cheng1	to prop up
+支应	支應	zhi1 ying4	to deal with
+直径	直徑	zhi2 jing4	diameter
+值钱	值錢	zhi2 qian2	valuable
+质量	質量	zhi2 liang4	quality
+质疑	質疑	zhi2 yi2	to call into question
+职务	職務	zhi2 wu4	post
+职责	職責	zhi2 ze2	duty
+执照	執照	zhi2 zhao4	license
+执政	執政	zhi2 zheng4	to hold power
+执着	執著	zhi2 zhuo2	to be strongly attached to
+指标	指標	zhi3 biao1	(production) target
+指点	指點	zhi3 dian3	to point out
+指挥	指揮	zhi3 hui1	to conduct
+指南针	指南針	zhi3 nan2 zhen1	compass
+指数	指數	zhi3 shu4	(numerical, statistical) index
+指头	指頭	zhi3 tou5	finger
+指纹	指紋	zhi3 wen2	fingerprint
+治标	治標	zhi4 biao1	to treat only the symptoms but not the root cause
+治疗	治療	zhi4 liao2	to treat (an illness)
+致词	致詞	zhi4 ci2	to make a speech
+制订	制訂	zhi4 ding4	to work out
+制品	製品	zhi4 pin3	products
+滞留	滯留	zhi4 liu2	to detain
+中断	中斷	zhong1 duan4	to cut short
+中叶	中葉	zhong1 ye4	mid- (e.g. mid-century)
+中医	中醫	zhong1 yi1	traditional Chinese medical science
+忠实	忠實	zhong1 shi2	faithful
+终场	終場	zhong1 chang3	end (of a performance or sports match)
+终结	終結	zhong1 jie2	end
+终究	終究	zhong1 jiu4	in the end
+终身	終身	zhong1 shen1	lifelong
+种种	種種	zhong3 zhong3	all kinds of
+种植	種植	zhong4 zhi2	to plant
+中风	中風	zhong4 feng1	to suffer a paralyzing stroke
+中奖	中獎	zhong4 jiang3	to win a prize
+重镇	重鎮	zhong4 zhen4	strategic town
+周边	周邊	zhou1 bian1	periphery
+周详	周詳	zhou1 xiang2	meticulous
+周游	周遊	zhou1 you2	to travel around
+周转	周轉	zhou1 zhuan3	to rotate
+皱	皺	zhou4	to wrinkle
+皱纹	皺紋	zhou4 wen2	wrinkle
+诸多	諸多	zhu1 duo1	(used for abstract things) a good deal, a lot of
+主导	主導	zhu3 dao3	leading
+主见	主見	zhu3 jian4	one's own view
+主权	主權	zhu3 quan2	sovereignty
+主义	主義	zhu3 yi4	-ism
+主轴	主軸	zhu3 zhou2	axis
+嘱咐	囑咐	zhu3 fu4	to tell
+瞩目	矚目	zhu3 mu4	to focus attention upon
+注视	注視	zhu4 shi4	to watch attentively
+住户	住戶	zhu4 hu4	household
+伫立	佇立	zhu4 li4	to stand for a long time
+驻	駐	zhu4	to halt
+抓紧	抓緊	zhua1 jin3	to grasp firmly
+专柜	專櫃	zhuan1 gui4	sales counter dedicated to a certain kind of product (e.g. alcohol)
+专员	專員	zhuan1 yuan2	assistant director
+专制	專制	zhuan1 zhi4	autocracy
+砖	磚	zhuan1	brick
+转动	轉動	zhuan3 dong4	to turn sth around
+转化	轉化	zhuan3 hua4	to change
+转手	轉手	zhuan3 shou3	to pass on
+转眼	轉眼	zhuan3 yan3	in a flash
+转移	轉移	zhuan3 yi2	to shift
+撰写	撰寫	zhuan4 xie3	to write
+庄严	莊嚴	zhuang1 yan2	solemn
+装备	裝備	zhuang1 bei4	equipment
+装潢	裝潢	zhuang1 huang2	to mount (a picture)
+装配	裝配	zhuang1 pei4	to assemble
+装运	裝運	zhuang1 yun4	to ship
+装置	裝置	zhuang1 zhi4	to install
+壮观	壯觀	zhuang4 guan1	spectacular
+壮丽	壯麗	zhuang4 li4	magnificence
+状元	狀元	zhuang4 yuan2	top scorer in the palace examination (highest rank of the Imperial examination system)
+准则	準則	zhun3 ze2	norm
+准许	准許	zhun3 xu3	to allow
+着手	著手	zhuo2 shou3	to put one's hand to it
+着眼	著眼	zhuo2 yan3	to have one's eyes on (a goal)
+着重	著重	zhuo2 zhong4	to put emphasis on
+资深	資深	zi1 shen1	veteran (journalist etc)
+资助	資助	zi1 zhu4	to subsidize
+姿势	姿勢	zi1 shi4	posture
+姿态	姿態	zi1 tai4	attitude
+子弹	子彈	zi3 dan4	bullet
+子孙	子孫	zi3 sun1	offspring
+紫外线	紫外線	zi3 wai4 xian4	ultraviolet ray
+自称	自稱	zi4 cheng1	to call oneself
+自费	自費	zi4 fei4	(be) at one's own expense
+自觉	自覺	zi4 jue2	conscious
+自满	自滿	zi4 man3	complacent
+自传	自傳	zi4 zhuan4	autobiography
+字体	字體	zi4 ti3	calligraphic style
+字样	字樣	zi4 yang4	model or template character
+总裁	總裁	zong3 cai2	chairman
+总得	總得	zong3 dei3	must
+总额	總額	o5 ge2	total (amount or value)
+总和	總和	zong3 he2	sum
+总结	總結	zong3 jie2	to sum up
+总经理	總經理	zong3 jing1 li3	general manager
+总数	總數	zong3 shu4	total
+纵火	縱火	zong4 huo3	to set on fire
+纵容	縱容	zong4 rong2	to indulge
+纵使	縱使	zong4 shi3	even if
+租赁	租賃	zu1 lin4	to rent
+足够	足夠	zu2 gou4	enough
+阻挡	阻擋	zu3 dang3	to stop
+阻挠	阻撓	zun3 ao2	to thwart
+组装	組裝	zu3 zhuang1	to assemble and install
+钻研	鑽研	zuan1 yan2	to study meticulously
+罪恶	罪惡	zui4 e4	crime
+尊严	尊嚴	zun1 yan2	dignity
+作风	作風	zuo4 feng1	style
+作战	作戰	zuo4 zhan4	combat
+作证	作證	zuo4 zheng4	to bear witness
+坐镇	坐鎮	zuo4 zhen4	(of a commanding officer) to keep watch
+座谈	座談	zuo4 tan2	to have an informal discussion
+座右铭	座右銘	zuo4 you4 ming2	motto


### PR DESCRIPTION
Many people are introduced to Simplified Chinese (Simp) first, but some may want to learn Traditional Chinese (Trad) afterwards. The Trad forms of the words in the HSK lists have several mistakes and many words are shared between Simp and Trad. To minimize learning efforts for people with Simp knowledge, I created a few lists based on the [TOCFL (華語文能力測驗) dataset](https://github.com/tomcumming/tocfl-word-list/blob/master/dist/simplified.csv) and only included words that differ between Simp and Trad.